### PR TITLE
Enable test for getLoginName (Fixes #1487)

### DIFF
--- a/tests/all.T
+++ b/tests/all.T
@@ -11,7 +11,19 @@ test('forkprocess01', [ only_compiler_types(['ghc']),
 # user001 may fail due to this bug in glibc:
 #   http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=466647
 #
-test('user001', normal, compile_and_run, ['-package unix'])
+# user001 may also fail on GNU/Linux when using a terminal emulator that doesn't
+# write login records to /var/run/utmp. Running:
+#   $ logname
+# should print your login name. If it doesn't, the getLoginName test in user001
+# will fail, and that's why you are here. Try xterm.
+#
+# Ticket #1487. The glibc implementation of getlogin, which is called by
+# getLoginName, requires that a terminal is connected to filedescriptor 0.
+# See: https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/getlogin.c
+# Therefore, we use the no_stdin option, and have to omit the 'ghci' way,
+# because it relies on redirecting stdin from file.
+#
+test('user001', [no_stdin, omit_ways(['ghci'])], compile_and_run, ['-package unix'])
 test('resourceLimit', normal, compile_and_run, ['-package unix'])
 
 x86FreeBsdFail = when(platform('i386-unknown-freebsd'), expect_fail)

--- a/tests/user001.hs
+++ b/tests/user001.hs
@@ -17,11 +17,11 @@ main = do p "getRealUserID"        $ getRealUserID
           p "getEffectiveUserID"   $ getEffectiveUserID
           p "getEffectiveGroupID"  $ getEffectiveGroupID
           p "getGroups"            $ getGroups
-          -- p "getLoginName"         $ getLoginName
+          p "getLoginName"         $ getLoginName
           p "getEffectiveUserName" $ getEffectiveUserName
           p "getGroupEntryForID"   $ getRealGroupID >>= getGroupEntryForID
           p "getGroupEntryForName" $ getRealGroupID >>= getGroupEntryForID >>= getGroupEntryForName . groupName
           p "getAllGroupEntries"   $ getAllGroupEntries
           p "getUserEntryForID"    $ getRealUserID >>= getUserEntryForID
-          -- p "getUserEntryForName"  $ getLoginName >>= getUserEntryForName
+          p "getUserEntryForName"  $ getLoginName >>= getUserEntryForName
           p "getAllUserEntries"    $ getAllUserEntries

--- a/tests/user001.stdout
+++ b/tests/user001.stdout
@@ -3,9 +3,11 @@ getRealGroupID: OK
 getEffectiveUserID: OK
 getEffectiveGroupID: OK
 getGroups: OK
+getLoginName: OK
 getEffectiveUserName: OK
 getGroupEntryForID: OK
 getGroupEntryForName: OK
 getAllGroupEntries: OK
 getUserEntryForID: OK
+getUserEntryForName: OK
 getAllUserEntries: OK


### PR DESCRIPTION
https://ghc.haskell.org/trac/ghc/ticket/1487

Make use of no_stdin test option, introduced explictly for this purpose
in GHC commit [fa52a8c9d8eae5e3fc4c0cf0e5672875e161e05c](https://github.com/ghc/ghc/commit/fa52a8c9d8eae5e3fc4c0cf0e5672875e161e05c)
