### PR TITLE
Add haddock comments on RTLD_NEXT and RTLD_DEFAULT

### DIFF
--- a/System/Posix/DynamicLinker/Prim.hsc
+++ b/System/Posix/DynamicLinker/Prim.hsc
@@ -51,9 +51,6 @@ import Foreign.C.String	( CString )
 --
 -- If you fail to test the flag and use it although it is undefined,
 -- 'packDL' will throw an error.
---
--- The same applies to RTLD_LOCAL which isn't available on
--- cygwin.
 
 haveRtldNext :: Bool
 
@@ -69,12 +66,8 @@ foreign import ccall unsafe "__hsunix_rtldDefault" rtldDefault :: Ptr a
 #endif /* HAVE_RTLDDEFAULT */
 
 haveRtldLocal :: Bool
-
-#ifdef HAVE_RTLDLOCAL
 haveRtldLocal = True
-#else /* HAVE_RTLDLOCAL */
-haveRtldLocal = False
-#endif /* HAVE_RTLDLOCAL */
+{-# DEPRECATED haveRtldLocal "defaults to True" #-}
 
 
 -- |Flags for 'System.Posix.DynamicLinker.dlopen'.
@@ -98,12 +91,7 @@ packRTLDFlag :: RTLDFlags -> CInt
 packRTLDFlag RTLD_LAZY = #const RTLD_LAZY
 packRTLDFlag RTLD_NOW = #const RTLD_NOW
 packRTLDFlag RTLD_GLOBAL = #const RTLD_GLOBAL
-
-#ifdef HAVE_RTLDLOCAL
 packRTLDFlag RTLD_LOCAL = #const RTLD_LOCAL
-#else /* HAVE_RTLDLOCAL */
-packRTLDFlag RTLD_LOCAL = error "RTLD_LOCAL not available"
-#endif /* HAVE_RTLDLOCAL */
 
 
 -- |Flags for 'System.Posix.DynamicLinker.dlsym'. Notice that 'Next'

--- a/configure.ac
+++ b/configure.ac
@@ -155,21 +155,6 @@ AC_EGREP_CPP(yes,
   AC_MSG_RESULT(no)
   ])    
 
-dnl ** RTLD_LOCAL isn't available on cygwin
-AC_MSG_CHECKING(for RTLD_LOCAL from dlfcn.h)
-AC_EGREP_CPP(yes,
-[
- #include <dlfcn.h>
- #ifdef RTLD_LOCAL
-        yes
- #endif
-], [
-  AC_MSG_RESULT(yes)
-  AC_DEFINE([HAVE_RTLDLOCAL], [1], [Define to 1 if RTLD_LOCAL is available.])
-], [
-  AC_MSG_RESULT(no)
-  ])    
-
 AC_CHECK_FUNCS(openpty,,
    AC_CHECK_LIB(util,openpty,
      [AC_DEFINE(HAVE_OPENPTY) EXTRA_LIBS="$EXTRA_LIBS util"],


### PR DESCRIPTION
Related to ticket [8902](https://ghc.haskell.org/trac/ghc/ticket/8902).

Plus code cleanup, including deprecating haveRtldLocal.
