### PR TITLE
fix _FILE_OFFSET_BITS redefined warning on Solaris/x86

### DIFF
--- a/System/Posix/SharedMem.hsc
+++ b/System/Posix/SharedMem.hsc
@@ -19,6 +19,8 @@ module System.Posix.SharedMem
     (ShmOpenFlags(..), shmOpen, shmUnlink)
     where
 
+#include "HsUnixConfig.h"
+
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <fcntl.h>


### PR DESCRIPTION
The issue is that sys/types.h header on Solaris includes somehow
/usr/include/sys/feature_tests.h which tests if _FILE_OFFSET_BITS
is defined and if not, then it defines it to 32 if we're compiling
32 bit code (x86). This is simply wrong since we'd like to have it
defined to 64. The issue is solved by including HsUnixConfig.h first
which defines _FILE_OFFSET_BITS to 64 and feature_tests.h is later
OK with that.
