### PR TITLE
Do not blindly add libdl to extra libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,7 +183,7 @@ else
 fi
 
 # Avoid adding dl if absent or unneeded
-AC_CHECK_LIB(dl, dlopen, [EXTRA_LIBS="$EXTRA_LIBS dl"])
+AC_SEARCH_LIBS([dlopen], [dl], [EXTRA_LIBS="$EXTRA_LIBS $ac_lib"])
 
 # -{l,}pthread goo
 AC_CANONICAL_TARGET


### PR DESCRIPTION
On some systems dlopen() is available without libdl (illumos, solaris).
Sometimes libdl.so cannot be loaded by runtime linker, see
https://ghc.haskell.org/trac/ghc/ticket/8713
