### PR TITLE
fix getGroupEntryForID/Name on Solaris

### DIFF
--- a/System/Posix/User.hsc
+++ b/System/Posix/User.hsc
@@ -207,7 +207,7 @@ getGroupEntryForID gid =
    doubleAllocWhileERANGE "getGroupEntryForID" "group" grBufSize unpackGroupEntry $
      c_getgrgid_r gid pgr
 
-foreign import ccall unsafe "getgrgid_r"
+foreign import ccall unsafe "__hsunix_getgrgid_r"
   c_getgrgid_r :: CGid -> Ptr CGroup -> CString
 		 -> CSize -> Ptr (Ptr CGroup) -> IO CInt
 #else
@@ -226,7 +226,7 @@ getGroupEntryForName name =
       doubleAllocWhileERANGE "getGroupEntryForName" "group" grBufSize unpackGroupEntry $
         c_getgrnam_r pstr pgr
 
-foreign import ccall unsafe "getgrnam_r"
+foreign import ccall unsafe "__hsunix_getgrnam_r"
   c_getgrnam_r :: CString -> Ptr CGroup -> CString
 		 -> CSize -> Ptr (Ptr CGroup) -> IO CInt
 #else

--- a/cbits/HsUnix.c
+++ b/cbits/HsUnix.c
@@ -182,3 +182,18 @@ HsInt __hsunix_long_path_size(void) {
 #endif
 }
 
+#ifdef HAVE_GETGRGID_R
+// getgrgid_r is a macro on some platforms, so we need a wrapper:
+int __hsunix_getgrgid_r(gid_t gid, struct group *grp, char *buf, size_t len,
+                        struct group **res) {
+    return getgrgid_r(gid, grp, buf, len, res);
+}
+#endif
+
+#ifdef HAVE_GETGRNAM_R
+// getgrnam_r is a macro on some platforms, so we need a wrapper:
+int __hsunix_getgrnam_r(const char *cb, struct group *grp, char *buf, int len,
+                        struct group **res) {
+    return getgrnam_r(cb, grp, buf, len, res);
+}
+#endif


### PR DESCRIPTION
This patch fixes getGroupEntryForID and getGroupEntryForName on Solaris
The issue on Solaris is that it defines both required getgrgid_r
and getgrnam_r functions as CPP macros which depending on configuration
are mapped to real function implementations with different names.
The issue is solved by common Unix library way of definig wrappers
for those functions in HsUnix.c and this way CPP will do its job correctly
