### PR TITLE
Retry process execution in case of ENOTDIR

### DIFF
--- a/cbits/execvpe.c
+++ b/cbits/execvpe.c
@@ -120,6 +120,7 @@ execvpe(char *name, char *const argv[], char **envp)
 	case EACCES:
 	    eacces = 1;
 	    break;
+	case ENOTDIR:
 	case ENOENT:
 	    break;
 	case ENOEXEC:


### PR DESCRIPTION
Copied from https://ghc.haskell.org/trac/ghc/ticket/9393

 If PATH environment variable contains non directory component,
execvpe fails by ENOTDIR.

For example, if "/tmp/foo" is a regular file, the following program fails with PATH contains "/tmp/foo".

``` haskell
module Main where

import System.Environment
import System.Posix.Process

main :: IO ()
main = do
    env <- getEnvironment
    executeFile "echo" True [] (Just env)
    return ()
```

``` bash
$ PATH=/tmp/foo:$PATH runghc a.hs   
a.hs: echo: executeFile: inappropriate type (Not a directory)
```

See for example, ​https://github.com/haskell/cabal/issues/1723
