### PR TITLE
Make read and write system calls interruptible when GHC >= 7.1

### DIFF
--- a/System/Posix/IO/Common.hsc
+++ b/System/Posix/IO/Common.hsc
@@ -1,7 +1,7 @@
 {-# LANGUAGE NondecreasingIndentation, RecordWildCards #-}
 #ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Trustworthy #-}
-#if __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE InterruptibleFFI #-}
 #endif
 #endif
@@ -402,7 +402,7 @@ fdReadBuf fd buf nbytes =
     throwErrnoIfMinus1Retry "fdReadBuf" $
       c_safe_read (fromIntegral fd) (castPtr buf) nbytes
 
-#if __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 701
 foreign import ccall interruptible "read"
 #else
 foreign import ccall safe "read"
@@ -426,7 +426,7 @@ fdWriteBuf fd buf len =
     throwErrnoIfMinus1Retry "fdWriteBuf" $
       c_safe_write (fromIntegral fd) (castPtr buf) len
 
-#if __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 701
 foreign import ccall interruptible "write"
 #else
 foreign import ccall safe "write"


### PR DESCRIPTION
When managing a serial device I can't System.Timeout the whole process if it is blocked waiting for input. The solution is to use non blockign reads, select or sleep but having a higher level timeout is desirable.

Are there any known issues with this? 
How is the version number updated with a change like this one?

I tested it on Linux and OS X and works if compiled with -threaded
