### PR TITLE
fix getGroupEntryForID/Name on Solaris

### DIFF
--- a/System/Posix/User.hsc
+++ b/System/Posix/User.hsc
@@ -1,5 +1,5 @@
 #ifdef __GLASGOW_HASKELL__
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Trustworthy, CApiFFI #-}
 #endif
 -----------------------------------------------------------------------------
 -- |
@@ -207,7 +207,7 @@ getGroupEntryForID gid =
    doubleAllocWhileERANGE "getGroupEntryForID" "group" grBufSize unpackGroupEntry $
      c_getgrgid_r gid pgr
 
-foreign import ccall unsafe "getgrgid_r"
+foreign import capi unsafe "HsUnix.h getgrgid_r"
   c_getgrgid_r :: CGid -> Ptr CGroup -> CString
 		 -> CSize -> Ptr (Ptr CGroup) -> IO CInt
 #else
@@ -226,7 +226,7 @@ getGroupEntryForName name =
       doubleAllocWhileERANGE "getGroupEntryForName" "group" grBufSize unpackGroupEntry $
         c_getgrnam_r pstr pgr
 
-foreign import ccall unsafe "getgrnam_r"
+foreign import capi unsafe "HsUnix.h getgrnam_r"
   c_getgrnam_r :: CString -> Ptr CGroup -> CString
 		 -> CSize -> Ptr (Ptr CGroup) -> IO CInt
 #else

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+
+  * Fix `getGroupEntryForID/getGroupEntryForName' on Solaris. Solaris uses
+    CPP macros for required getgrgid_r and getgrnam_r functions definition
+    so the fix is to change from C ABI calling convention to C API calling
+    convention
+
 ## 2.7.0.1  *Mar 2014*
 
   * Bundled with GHC 7.8.1


### PR DESCRIPTION
This patch fixes getGroupEntryForID and getGroupEntryForName on Solaris
The issue on Solaris is that it defines both required getgrgid_r
and getgrnam_r functions as CPP macros which depending on configuration
are mapped to real function implementations with different names.
The issue is solved by using C API calling convention instead of platform
C ABI calling convention.
