### PR TITLE
System.Posix.Files.fileAccess fails inside OS X sandbox

### DIFF
--- a/System/Posix/Files.hsc
+++ b/System/Posix/Files.hsc
@@ -152,7 +152,8 @@ access name flags =
     if (r == 0)
         then return True
         else do err <- getErrno
-                if (err == eACCES || err == eROFS || err == eTXTBSY)
+                if (err == eACCES || err == eROFS || err == eTXTBSY ||
+                    err == ePERM)
                    then return False
                    else throwErrnoPath "fileAccess" name
 

--- a/System/Posix/Files/ByteString.hsc
+++ b/System/Posix/Files/ByteString.hsc
@@ -158,7 +158,8 @@ access name flags =
     if (r == 0)
         then return True
         else do err <- getErrno
-                if (err == eACCES || err == eROFS || err == eTXTBSY)
+                if (err == eACCES || err == eROFS || err == eTXTBSY ||
+                    err == ePERM)
                    then return False
                    else throwErrnoPath "fileAccess" name
 


### PR DESCRIPTION
Hi,

similar to what has been reported in https://ghc.haskell.org/trac/ghc/ticket/8741, the same code fails when run inside OS X' sandboxing mechanism because `access(2)` sets errno to `EPERM` rather than `EACCES` when access is denied due to sandboxing rules rather than file modes.

As with the ticket referenced above, this breaks Cabal on OS X when used inside a sandbox (which is the case for every MacPorts port):

```
Configuring stm-2.4.2...
Flags chosen: base4=True
Dependency array -any: using array-0.5.0.0
Dependency base ==4.*: using base-4.7.0.1
Setup: /usr/bin/ar: permission denied
```

The top commit adds `ePERM` as another errno value to be handled gracefully. Since the same code exists in the ByteString variant of the interface, I've also changed it there (and ported the change from #8741, which was also missing). I took the liberty of removing the remaining tabs in this file, because there still were some in the block I changed.

I'm not sure whether this is the right place to open this ticket (http://hackage.haskell.org/package/unix says it is, #8741 in GHC Trac suggests it isn't), so please let me know if I should take this patch elsewhere.
