### PR TITLE
Define and export setitimer, getitimer.

### DIFF
--- a/System/Posix/Time.hsc
+++ b/System/Posix/Time.hsc
@@ -18,9 +18,24 @@
 -----------------------------------------------------------------------------
 
 module System.Posix.Time (
-        epochTime,
-        -- ToDo: lots more from sys/time.h
-        -- how much already supported by System.Time?
+
+      epochTime
+
+    #ifdef HAVE_SETITIMER
+    , ITimerType(..)
+
+    , TimeVal(TimeVal)
+    , timeValSeconds
+    , timeValMicroseconds
+
+    , ITimerVal(ITimerVal)
+    , itimerValInterval
+    , itimerValValue
+
+    , setitimer
+    , getitimer
+    #endif
+
   ) where
 
 #include "HsUnix.h"
@@ -39,3 +54,88 @@ epochTime = throwErrnoIfMinus1 "epochTime" (c_time nullPtr)
 
 foreign import ccall unsafe "__hsunix_time"
   c_time :: Ptr CTime -> IO CTime
+
+#ifdef HAVE_SETITIMER
+
+-- | Haskell expression of struct timeval: seconds and microseconds.
+data TimeVal = TimeVal {
+    tv_sec :: Int
+  , tv_usec :: Int
+  }
+
+timeValSeconds :: TimeVal -> Int
+timeValSeconds = tv_sec
+
+timeValMicroseconds :: TimeVal -> Int
+timeValMicroseconds = tv_usec
+
+instance Storable TimeVal where
+  sizeOf _ = (#size struct timeval)
+  alignment _ = alignment (undefined :: CLong)
+  peek ptr = do
+    sec <- (#peek struct timeval, tv_sec) ptr
+    usec <- (#peek struct timeval, tv_usec) ptr
+    return $ TimeVal sec usec
+  poke ptr timeval = do
+    (#poke struct timeval, tv_sec) ptr (tv_sec timeval)
+    (#poke struct timeval, tv_usec) ptr (tv_usec timeval)
+
+-- | Haskell expression of the timer types:
+--   ITIMER_REAL, ITIMER_VIRTUAL, and ITIMER_PROF
+data ITimerType = ITimerReal | ITimerVirtual | ITimerProf
+
+-- | Not exported.
+iTimerTypeToCInt :: ITimerType -> CInt
+iTimerTypeToCInt ITimerReal = #const ITIMER_REAL
+iTimerTypeToCInt ITimerVirtual = #const ITIMER_VIRTUAL
+iTimerTypeToCInt ITimerProf = #const ITIMER_PROF
+
+-- | Haskell expression of struct itimerval
+data ITimerVal = ITimerVal {
+    it_interval :: TimeVal
+  , it_value :: TimeVal
+  }
+
+itimerValInterval :: ITimerVal -> TimeVal
+itimerValInterval = it_interval
+
+itimerValValue :: ITimerVal -> TimeVal
+itimerValValue = it_value
+
+instance Storable ITimerVal where
+  sizeOf _ = (#size struct itimerval)
+  alignment _ = alignment (undefined :: TimeVal)
+  peek ptr = do
+    interval <- (#peek struct itimerval, it_interval) ptr
+    value <- (#peek struct itimerval, it_value) ptr
+    return $ ITimerVal interval value
+  poke ptr itimerval = do
+    (#poke struct itimerval, it_interval) ptr (it_interval itimerval)
+    (#poke struct itimerval, it_value) ptr (it_value itimerval)
+
+-- | Works like getitimer from sys/time.h. Nothing is returned in case of
+--   error. As it says in the setitimer man page, if there is no timer set, you
+--   then the ITimerVal will have its itimerValValue field set to 0 (TimerVal
+--   with timValSeconds and timeValMicroseconds at 0).
+getitimer :: ITimerType -> IO (Maybe ITimerVal)
+getitimer itimerType = alloca $ \itimerValPtr -> do
+    status <- c_getitimer (iTimerTypeToCInt itimerType) itimerValPtr
+    if ((fromIntegral status) == 0)
+    then fmap Just (peek itimerValPtr)
+    else (return Nothing)
+
+-- | Works like setitimer from sys/time.h, without support for giving an
+--   itimerval pointer to store the old itimerval.
+--   If there is an error, False is given; True otherwise.
+setitimer :: ITimerType -> ITimerVal -> IO Bool
+setitimer itimerType itimerVal = alloca $ \itimerValPtr -> do
+    poke itimerValPtr itimerVal
+    status <- c_setitimer (iTimerTypeToCInt itimerType) itimerValPtr nullPtr
+    return (if ((fromIntegral status) == 0) then True else False)
+
+foreign import ccall unsafe "setitimer"
+  c_setitimer :: CInt -> Ptr ITimerVal -> Ptr ITimerVal -> IO CInt
+
+foreign import ccall unsafe "getitimer"
+  c_getitimer :: CInt -> Ptr ITimerVal -> IO CInt
+#endif

--- a/System/Posix/Unistd.hsc
+++ b/System/Posix/Unistd.hsc
@@ -34,8 +34,6 @@ module System.Posix.Unistd (
     fileSynchronise,
     fileSynchroniseDataOnly,
 
-    ualarm,
-
   {-
     ToDo from unistd.h:
       confstr,
@@ -46,6 +44,9 @@ module System.Posix.Unistd (
 
     -- should be in System.Posix.Files?
     pathconf, fpathconf,
+
+    -- System.Posix.Signals
+    ualarm,
 
     -- System.Posix.IO
     read, write,
@@ -263,14 +264,3 @@ foreign import capi safe "unistd.h fdatasync"
 fileSynchroniseDataOnly _ = ioError (ioeSetLocation unsupportedOperation
                                      "fileSynchroniseDataOnly")
 #endif
-
--- | Call ualarm. On some systems, the values must be in [0, 1000000) or else
---   nothing will happen. Make your checks.
---
---   ToDo perhaps give IO (Maybe Int) to indicate failure, by checking if ualarm
---   returns EINVAL.
-ualarm :: Int -> Int -> IO Int
-ualarm usecs interval = fmap fromIntegral $ c_usleep (fromIntegral usecs) (fromIntegral interval)
-
-foreign import ccall safe "ualarm"
-  c_usleep :: CUInt -> CUInt -> IO CUInt

--- a/System/Posix/Unistd.hsc
+++ b/System/Posix/Unistd.hsc
@@ -34,6 +34,8 @@ module System.Posix.Unistd (
     fileSynchronise,
     fileSynchroniseDataOnly,
 
+    ualarm,
+
   {-
     ToDo from unistd.h:
       confstr,
@@ -44,9 +46,6 @@ module System.Posix.Unistd (
 
     -- should be in System.Posix.Files?
     pathconf, fpathconf,
-
-    -- System.Posix.Signals
-    ualarm,
 
     -- System.Posix.IO
     read, write,
@@ -264,3 +263,14 @@ foreign import capi safe "unistd.h fdatasync"
 fileSynchroniseDataOnly _ = ioError (ioeSetLocation unsupportedOperation
                                      "fileSynchroniseDataOnly")
 #endif
+
+-- | Call ualarm. On some systems, the values must be in [0, 1000000) or else
+--   nothing will happen. Make your checks.
+--
+--   ToDo perhaps give IO (Maybe Int) to indicate failure, by checking if ualarm
+--   returns EINVAL.
+ualarm :: Int -> Int -> IO Int
+ualarm usecs interval = fmap fromIntegral $ c_usleep (fromIntegral usecs) (fromIntegral interval)
+
+foreign import ccall safe "ualarm"
+  c_usleep :: CUInt -> CUInt -> IO CUInt


### PR DESCRIPTION
~~Export `ualarm` so that we can have microsecond resolution for our `SIGALRM`s.~~

Formerly "Define and export ualarm". That has been dropped in favour of `setitimer` and `getitimer`.
