### PR TITLE
Modifying declaration of execvpe on OpenBSD

### DIFF
--- a/cbits/execvpe.c
+++ b/cbits/execvpe.c
@@ -59,7 +59,11 @@
  */
 
 int
+#ifdef __OpenBSD__
+execvpe(const char *name, char *const *argv, char *const *envp)
+#else
 execvpe(char *name, char *const argv[], char **envp)
+#endif
 {
     register int lp, ln;
     register char *p;

--- a/include/execvpe.h
+++ b/include/execvpe.h
@@ -20,7 +20,11 @@
 
 #if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(_WIN32)
 #ifndef __QNXNTO__
+#ifdef __OpenBSD__
+extern int execvpe(const char *, char *const *, char *const *);
+#else
 extern int execvpe(char *name, char *const argv[], char **envp);
+#endif
 #endif
 extern void pPrPr_disableITimers (void);
 #endif


### PR DESCRIPTION
This is to avoid a conflict with the declaration in OpenBSD's
/usr/include/unistd.h, yielding "Bad header file: execvpe.h" in the
configure phase.
