### PR TITLE
Tighten Safe Haskell bounds, fixes new warning in GHC 7.10.

### DIFF
--- a/System/Posix/DynamicLinker/Module.hsc
+++ b/System/Posix/DynamicLinker/Module.hsc
@@ -1,4 +1,6 @@
-#ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ >= 709
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/System/Posix/DynamicLinker/Prim.hsc
+++ b/System/Posix/DynamicLinker/Prim.hsc
@@ -1,5 +1,8 @@
 #ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Trustworthy #-}
+#if __GLASGOW_HASKELL__ >= 709
+{-# OPTIONS_GHC -fno-warn-trustworthy-safe #-}
+#endif
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/System/Posix/Env.hsc
+++ b/System/Posix/Env.hsc
@@ -1,4 +1,6 @@
-#ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ >= 709
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/System/Posix/IO.hsc
+++ b/System/Posix/IO.hsc
@@ -1,4 +1,6 @@
-#ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ >= 709
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/System/Posix/IO/ByteString.hsc
+++ b/System/Posix/IO/ByteString.hsc
@@ -1,4 +1,6 @@
-#ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ >= 709
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/System/Posix/SharedMem.hsc
+++ b/System/Posix/SharedMem.hsc
@@ -1,4 +1,6 @@
-#ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ >= 709
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/System/Posix/Temp.hsc
+++ b/System/Posix/Temp.hsc
@@ -1,4 +1,6 @@
-#ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ >= 709
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/System/Posix/Temp/ByteString.hsc
+++ b/System/Posix/Temp/ByteString.hsc
@@ -1,4 +1,6 @@
-#ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ >= 709
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Some of the Safe Haskell bounds can be improved. This also fixes warnings that will appear in 7.10 where we have a new warning flag (`--fwarn-trustworthy-safe`) that warns when a trustworthy module could be instead marked safe.
