### PR TITLE
Adds a more comprehensive check for fdatasync

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,26 @@ AC_CHECK_FUNCS([lutimes futimes])
 AC_CHECK_FUNCS([mkstemps mkdtemp])
 
 # Functions for file synchronization and allocation control
-AC_CHECK_FUNCS([fsync fdatasync])
+AC_CHECK_FUNCS([fsync])
+
+# A more comprehensive check that fdatasync exits
+# Necessary for platforms that have fdatasync in headers but have no
+# implementation
+dnl Originally provided by user copiousfreetime for the beanstalkd project
+dnl {{{ make sure that fdatasync exits
+AC_CACHE_CHECK([for fdatasync],[ac_cv_func_fdatasync],[
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <unistd.h>
+]],[[
+fdatasync(4);
+]])],
+[ac_cv_func_fdatasync=yes],
+[ac_cv_func_fdatasync=no])
+])
+AS_IF([test "x${ac_cv_func_fdatasync}" = "xyes"],
+ [AC_DEFINE([HAVE_FDATASYNC],[1],[If the system defines fdatasync])])
+dnl }}}
+
 AC_CHECK_FUNCS([posix_fadvise posix_fallocate])
 
 # Avoid adding rt if absent or unneeded


### PR DESCRIPTION
Some versions of OS X have fdatasync in the headers but don't include implementations in the standard library. This leads to a compile failure in configure.ac when using AC_CHECK_FUNCS.

This change explicitly attempts to compile a file containing a call to fdatasync and properly sets the AC_CHECK_FUNCS flags depending on the result of compilation.

May fix #37.