### PR TITLE
Add GHC 8.0.1 to test-matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ env:
  - CABALVER=1.18 GHCVER=7.8.3
  - CABALVER=1.18 GHCVER=7.8.4
  - CABALVER=1.22 GHCVER=7.10.1
+ - CABALVER=1.24 GHCVER=8.0.1
  - CABALVER=head GHCVER=head
 
 matrix:
   allow_failures:
+   - env: CABALVER=1.24 GHCVER=8.0.1
    - env: CABALVER=head GHCVER=head
 
 before_install:


### PR DESCRIPTION
What are the plans for supporting 8.0?

As is this isn't likely to work given the constraints in the cabal file.