### PR TITLE
Don't use readdir_r if deprecated

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`unix` package](http://hackage.haskell.org/package/unix)
 
+## 2.7.2.1  *Sep 2016*
+
+  * Don't use `readdir_r` if its deprecated.
+
 ## 2.7.2.0  *Apr 2016*
 
   * Bundled with GHC 8.0.1


### PR DESCRIPTION
GNU glibc 2.23 and later deprecate `readdir_r` in favour of plain old
`readdir` which in some upcoming POSIX standard is going to required to be
re-entrant.

Eventually we want to drop `readder_r` all together, but want to be
compatible with older unixen which may not have a re-entrant `readdir`.

Solution is to make systems with *known* re-entrant `readir` use that and
use `readdir_r` whereever we have it and don't *know* that `readdir` is
re-entrant.

Closes: https://github.com/haskell/unix/issues/70
