### PR TITLE
Add accessors for st_blocks and st_blksize

### DIFF
--- a/System/Posix/Files.hsc
+++ b/System/Posix/Files.hsc
@@ -59,6 +59,9 @@ module System.Posix.Files (
     isBlockDevice, isCharacterDevice, isNamedPipe, isRegularFile,
     isDirectory, isSymbolicLink, isSocket,
 
+    fileBlockSize,
+    fileBlocks,
+
     -- * Creation
     createNamedPipe,
     createDevice,

--- a/System/Posix/Files/ByteString.hsc
+++ b/System/Posix/Files/ByteString.hsc
@@ -59,6 +59,9 @@ module System.Posix.Files.ByteString (
     isBlockDevice, isCharacterDevice, isNamedPipe, isRegularFile,
     isDirectory, isSymbolicLink, isSocket,
 
+    fileBlockSize,
+    fileBlocks,
+
     -- * Creation
     createNamedPipe,
     createDevice,

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,9 @@ AC_CHECK_MEMBERS([struct stat.st_uatime])
 AC_CHECK_MEMBERS([struct stat.st_umtime])
 AC_CHECK_MEMBERS([struct stat.st_uctime])
 
+AC_CHECK_MEMBERS([struct stat.st_blocks])
+AC_CHECK_MEMBERS([struct stat.st_blksize])
+
 AC_CHECK_MEMBER([struct passwd.pw_gecos], [], [AC_DEFINE([HAVE_NO_PASSWD_PW_GECOS],[],[Ignore the pw_gecos member of passwd where it does not exist])], [[#include <pwd.h>]])
 
 # Functions for changing file timestamps


### PR DESCRIPTION
AFAIU st_blocks is mandatory in POSIX but st_blksize is part of the XSI option (whatever that means) so it's definition is protected by a feature test macro.

This depends on https://ghc.haskell.org/trac/ghc/ticket/12795.