### PR TITLE
Fix error message of `createSymbolicLink`.

### DIFF
--- a/System/Posix/Files.hsc
+++ b/System/Posix/Files.hsc
@@ -253,7 +253,7 @@ createSymbolicLink :: FilePath -> FilePath -> IO ()
 createSymbolicLink file1 file2 =
   withFilePath file1 $ \s1 ->
   withFilePath file2 $ \s2 ->
-  throwErrnoPathIfMinus1_ "createSymbolicLink" file1 (c_symlink s1 s2)
+  throwErrnoPathIfMinus1_ "createSymbolicLink" file2 (c_symlink s1 s2)
 
 foreign import ccall unsafe "symlink"
   c_symlink :: CString -> CString -> IO CInt

--- a/System/Posix/Files/ByteString.hsc
+++ b/System/Posix/Files/ByteString.hsc
@@ -259,7 +259,7 @@ createSymbolicLink :: RawFilePath -> RawFilePath -> IO ()
 createSymbolicLink file1 file2 =
   withFilePath file1 $ \s1 ->
   withFilePath file2 $ \s2 ->
-  throwErrnoPathIfMinus1_ "createSymbolicLink" file1 (c_symlink s1 s2)
+  throwErrnoPathIfMinus1_ "createSymbolicLink" file2 (c_symlink s1 s2)
 
 foreign import ccall unsafe "symlink"
   c_symlink :: CString -> CString -> IO CInt


### PR DESCRIPTION
Consider `ln` (or any other Unix tool):

    $ ln -s file1 file2
    $ ls -l file2
    lrwxrwxrwx 1 niklas niklas 5 Feb  8 03:09 file2 -> file1
    $ ln -s file1 file2
    ln: failed to create symbolic link 'file2': File exists

The file name mentioned in the error ("link2") is the one
that *could not be created*, not the content of the pointer.

`createSymbolicLink` got this wrong so far, it would print

    file1: createSymbolicLink: already exists (File exists)

which is wrong, this file doesn't already exist.

This commit fixes it.