### PR TITLE
Android doesn’t have telldir/seekdir in bionic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,8 +37,10 @@ AC_CHECK_FUNCS([nanosleep])
 AC_CHECK_FUNCS([ptsname])
 AC_CHECK_FUNCS([setitimer])
 AC_CHECK_FUNCS([readdir_r])
+
 dnl not available on android so check for it
-AC_CHECK_FUNCS([telldir seekdir])
+AC_CANONICAL_TARGET
+AS_CASE([$target_os],[*-android*],[],[AC_CHECK_FUNCS([telldir seekdir])])
 
 dnl When available, _NSGetEnviron() (defined in <crt_externs.h>) is
 dnl the preferred way to access environ(7)


### PR DESCRIPTION
The isse here is that while we try to use `AC_CHECK_FUNCS`, this will generate test code
that tries to link an object and check for linking errors.  However  GNU gold at least version
(binutils-2.25-0666073 2.25.51.20141117) 1.11, considers seekdir/telldir as part of the
default libs. Thus we would actually want to pass `-nodefaultlibs` to the linker. Doing so,
would result in erros due to not finding `-ldl`.

Fixes #91