### PR TITLE
Android doesn’t have mkstemps

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,8 @@ AC_CHECK_FUNCS([lutimes futimes])
 
 # Additional temp functions
 dnl androids bionic doesn't have mkstemps
+# We explicilty check for android, as the check AC_CHECK_FUNCS performs returns "yes" for mkstemps
+# when targetting android. See similar conditionals for seekdir and telldir.
 AS_CASE([$target_os],[*-android*],[AC_CHECK_FUNCS([mkdtemp])],[AC_CHECK_FUNCS([mkstemps mkdtemp])])
 
 # Functions for file synchronization and allocation control

--- a/configure.ac
+++ b/configure.ac
@@ -73,7 +73,8 @@ AC_CHECK_FUNCS([utimensat futimens])
 AC_CHECK_FUNCS([lutimes futimes])
 
 # Additional temp functions
-AC_CHECK_FUNCS([mkstemps mkdtemp])
+dnl androids bionic doesn't have mkstemps
+AS_CASE([$target_os],[*-android*],[AC_CHECK_FUNCS([mkdtemp])],[AC_CHECK_FUNCS([mkstemps mkdtemp])])
 
 # Functions for file synchronization and allocation control
 AC_CHECK_FUNCS([fsync])


### PR DESCRIPTION
However the check similarly to tell and seekdir succeeds. However we will generate the following error down the line:
```
/var/folders/fv/xqjrpfj516n5xq_m_ljpsjx00000gn/T/ghc13524_0/ghc_2.c:11:104: error:
     warning: implicit declaration of function 'mkstemps' is invalid in C99 [-Wimplicit-function-declaration]
   |
11 | HsInt32 ghczuwrapperZC1ZCunixzm2zi7zi2zi1ZCSystemziPosixziTempZCmkstemps(void* a1, HsInt32 a2) {return mkstemps(a1, a2);}
   |                                                                                                        ^
HsInt32 ghczuwrapperZC1ZCunixzm2zi7zi2zi1ZCSystemziPosixziTempZCmkstemps(void* a1, HsInt32 a2) {return mkstemps(a1, a2);}
                                                                                                       ^
```