### PR TITLE
Bump upper bound on base to < 4.13

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -63,7 +63,7 @@ library
         buildable: False
 
     build-depends:
-        base        >= 4.5     && < 4.12,
+        base        >= 4.5     && < 4.13,
         bytestring  >= 0.9.2   && < 0.11,
         time        >= 1.2     && < 1.9
 


### PR DESCRIPTION
See https://ghc.haskell.org/trac/ghc/ticket/15018.