### PR TITLE
allow building with time 1.9.x

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -71,7 +71,7 @@ library
     build-depends:
         base        >= 4.5     && < 4.13,
         bytestring  >= 0.9.2   && < 0.11,
-        time        >= 1.2     && < 1.9
+        time        >= 1.2     && < 1.10
 
     exposed-modules:
         System.Posix


### PR DESCRIPTION
New versions of time `time` compile fine with this code.