### PR TITLE
Resource: Fix warning in case of no RLIM_SAVED_{CUR,MAX}

### DIFF
--- a/System/Posix/Resource.hsc
+++ b/System/Posix/Resource.hsc
@@ -111,11 +111,17 @@ unpackRLimit other
 
 packRLimit :: ResourceLimit -> Bool -> CRLim
 packRLimit ResourceLimitInfinity _     = (#const RLIM_INFINITY)
-#ifdef RLIM_SAVED_CUR
+#if defined(RLIM_SAVED_CUR)
 packRLimit ResourceLimitUnknown  True  = (#const RLIM_SAVED_CUR)
 #endif
-#ifdef RLIM_SAVED_MAX
+#if defined(RLIM_SAVED_MAX)
 packRLimit ResourceLimitUnknown  False = (#const RLIM_SAVED_MAX)
+#endif
+#if ! defined(RLIM_SAVED_MAX) && !defined(RLIM_SAVED_CUR)
+packRLimit ResourceLimitUnknown  _     =
+    error
+      $ "System.Posix.Resource.packRLimit: " ++
+        "ResourceLimitUnknown but RLIM_SAVED_MAX/RLIM_SAVED_CUR not defined by platform"
 #endif
 packRLimit (ResourceLimit other) _     = fromIntegral other
 


### PR DESCRIPTION
This previously failed to build with a warning on FreeBSD 11.2