### PR TITLE
Fix issue 60: confusing error messages in rename/createLink/createSymbolicLink

### DIFF
--- a/System/Posix/ByteString/FilePath.hsc
+++ b/System/Posix/ByteString/FilePath.hsc
@@ -25,7 +25,8 @@ module System.Posix.ByteString.FilePath (
      throwErrnoPathIf_,
      throwErrnoPathIfNull,
      throwErrnoPathIfMinus1,
-     throwErrnoPathIfMinus1_
+     throwErrnoPathIfMinus1_,
+     throwErrnoTwoPathsIfMinus1_
   ) where
 
 import Foreign hiding ( void )
@@ -41,6 +42,9 @@ import Control.Monad
 import Data.ByteString
 import Data.ByteString.Char8 as BC
 import Prelude hiding (FilePath)
+#if !MIN_VERSION_base(4, 11, 0)
+import Data.Monoid ((<>))
+#endif
 
 -- | A literal POSIX file path
 type RawFilePath = ByteString
@@ -121,3 +125,9 @@ throwErrnoPathIfMinus1 = throwErrnoPathIf (== -1)
 --
 throwErrnoPathIfMinus1_ :: (Eq a, Num a) => String -> RawFilePath -> IO a -> IO ()
 throwErrnoPathIfMinus1_  = throwErrnoPathIf_ (== -1)
+
+-- | as 'throwErrnoTwoPathsIfMinus1_', but exceptions include two paths when appropriate.
+--
+throwErrnoTwoPathsIfMinus1_ :: (Eq a, Num a) => String -> RawFilePath -> RawFilePath -> IO a -> IO ()
+throwErrnoTwoPathsIfMinus1_  loc path1 path2 =
+    throwErrnoIfMinus1_ (loc <> " '" <> BC.unpack path1 <> "' to '" <> BC.unpack path2 <> "'")

--- a/System/Posix/Files.hsc
+++ b/System/Posix/Files.hsc
@@ -102,13 +102,18 @@ import System.Posix.Files.Common
 import System.Posix.Error
 import System.Posix.Internals
 
+#if !MIN_VERSION_base(4, 11, 0)
+import Data.Monoid ((<>))
+#endif
+
 import Data.Time.Clock.POSIX (POSIXTime)
 
 -- throwErrnoTwoPathsIfMinus1_
 --
 -- | For operations that require two paths (e.g., renaming a file)
+throwErrnoTwoPathsIfMinus1_ :: (Eq a, Num a) => String -> FilePath -> FilePath -> IO a -> IO ()
 throwErrnoTwoPathsIfMinus1_ loc path1 path2 =
-  throwErrnoIfMinus1_ (loc ++ " '" ++ path1 ++ "' to '" ++ path2 ++ "'")
+  throwErrnoIfMinus1_ (loc <> " '" <> path1 <> "' to '" <> path2 <> "'")
 
 -- -----------------------------------------------------------------------------
 -- chmod()

--- a/System/Posix/Files.hsc
+++ b/System/Posix/Files.hsc
@@ -104,6 +104,12 @@ import System.Posix.Internals
 
 import Data.Time.Clock.POSIX (POSIXTime)
 
+-- throwErrnoTwoPathsIfMinus1_
+--
+-- | For operations that require two paths (e.g., renaming a file)
+throwErrnoTwoPathsIfMinus1_ loc path1 path2 =
+  throwErrnoIfMinus1_ (loc ++ " '" ++ path1 ++ "' to '" ++ path2 ++ "'")
+
 -- -----------------------------------------------------------------------------
 -- chmod()
 
@@ -228,7 +234,7 @@ createLink :: FilePath -> FilePath -> IO ()
 createLink name1 name2 =
   withFilePath name1 $ \s1 ->
   withFilePath name2 $ \s2 ->
-  throwErrnoIfMinus1_ ("createLink (target: "++name1++") (linkpath: "++name2++")") (c_link s1 s2)
+  throwErrnoTwoPathsIfMinus1_ "createLink" name1 name2 (c_link s1 s2)
 
 -- | @removeLink path@ removes the link named @path@.
 --
@@ -252,7 +258,7 @@ createSymbolicLink :: FilePath -> FilePath -> IO ()
 createSymbolicLink name1 name2 =
   withFilePath name1 $ \s1 ->
   withFilePath name2 $ \s2 ->
-  throwErrnoIfMinus1_ ("createSymbolicLink (target: "++name1++") (linkpath: "++name2++")") (c_symlink s1 s2)
+  throwErrnoTwoPathsIfMinus1_ "createSymbolicLink" name1 name2 (c_symlink s1 s2)
 
 foreign import ccall unsafe "symlink"
   c_symlink :: CString -> CString -> IO CInt
@@ -290,7 +296,7 @@ rename :: FilePath -> FilePath -> IO ()
 rename name1 name2 =
   withFilePath name1 $ \s1 ->
   withFilePath name2 $ \s2 ->
-  throwErrnoIfMinus1_ ("rename "++name1++" to "++name2) (c_rename s1 s2)
+  throwErrnoTwoPathsIfMinus1_  "rename" name1 name2 (c_rename s1 s2)
 
 foreign import ccall unsafe "rename"
    c_rename :: CString -> CString -> IO CInt

--- a/System/Posix/Files.hsc
+++ b/System/Posix/Files.hsc
@@ -228,7 +228,7 @@ createLink :: FilePath -> FilePath -> IO ()
 createLink name1 name2 =
   withFilePath name1 $ \s1 ->
   withFilePath name2 $ \s2 ->
-  throwErrnoIfMinus1_ ("createLink "++name1++" to "++name2) (c_link s1 s2)
+  throwErrnoIfMinus1_ ("createLink (target: "++name1++") (linkpath: "++name2++")") (c_link s1 s2)
 
 -- | @removeLink path@ removes the link named @path@.
 --
@@ -241,18 +241,18 @@ removeLink name =
 -- -----------------------------------------------------------------------------
 -- Symbolic Links
 
--- | @createSymbolicLink file1 file2@ creates a symbolic link named @file2@
--- which points to the file @file1@.
+-- | @createSymbolicLink name1 name2@ creates a symbolic link named @name2@
+-- which points to the file @name1@.
 --
 -- Symbolic links are interpreted at run-time as if the contents of the link
 -- had been substituted into the path being followed to find a file or directory.
 --
 -- Note: calls @symlink@.
 createSymbolicLink :: FilePath -> FilePath -> IO ()
-createSymbolicLink file1 file2 =
-  withFilePath file1 $ \s1 ->
-  withFilePath file2 $ \s2 ->
-  throwErrnoIfMinus1_ ("createSymbolicLink "++file1++" to "++file2) (c_symlink s1 s2)
+createSymbolicLink name1 name2 =
+  withFilePath name1 $ \s1 ->
+  withFilePath name2 $ \s2 ->
+  throwErrnoIfMinus1_ ("createSymbolicLink (target: "++name1++") (linkpath: "++name2++")") (c_symlink s1 s2)
 
 foreign import ccall unsafe "symlink"
   c_symlink :: CString -> CString -> IO CInt

--- a/System/Posix/Files.hsc
+++ b/System/Posix/Files.hsc
@@ -228,7 +228,7 @@ createLink :: FilePath -> FilePath -> IO ()
 createLink name1 name2 =
   withFilePath name1 $ \s1 ->
   withFilePath name2 $ \s2 ->
-  throwErrnoPathIfMinus1_ "createLink" name1 (c_link s1 s2)
+  throwErrnoIfMinus1_ ("createLink "++name1++" to "++name2) (c_link s1 s2)
 
 -- | @removeLink path@ removes the link named @path@.
 --
@@ -252,7 +252,7 @@ createSymbolicLink :: FilePath -> FilePath -> IO ()
 createSymbolicLink file1 file2 =
   withFilePath file1 $ \s1 ->
   withFilePath file2 $ \s2 ->
-  throwErrnoPathIfMinus1_ "createSymbolicLink" file2 (c_symlink s1 s2)
+  throwErrnoIfMinus1_ ("createSymbolicLink "++file1++" to "++file2) (c_symlink s1 s2)
 
 foreign import ccall unsafe "symlink"
   c_symlink :: CString -> CString -> IO CInt
@@ -290,7 +290,7 @@ rename :: FilePath -> FilePath -> IO ()
 rename name1 name2 =
   withFilePath name1 $ \s1 ->
   withFilePath name2 $ \s2 ->
-  throwErrnoPathIfMinus1_ "rename" name1 (c_rename s1 s2)
+  throwErrnoIfMinus1_ ("rename "++name1++" to "++name2) (c_rename s1 s2)
 
 foreign import ccall unsafe "rename"
    c_rename :: CString -> CString -> IO CInt

--- a/System/Posix/Files/ByteString.hsc
+++ b/System/Posix/Files/ByteString.hsc
@@ -234,7 +234,7 @@ createLink :: RawFilePath -> RawFilePath -> IO ()
 createLink name1 name2 =
   withFilePath name1 $ \s1 ->
   withFilePath name2 $ \s2 ->
-  throwErrnoPathIfMinus1_ "createLink" name1 (c_link s1 s2)
+  throwErrnoTwoPathsIfMinus1_ "createLink" name1 name2 (c_link s1 s2)
 
 -- | @removeLink path@ removes the link named @path@.
 --
@@ -255,10 +255,10 @@ removeLink name =
 --
 -- Note: calls @symlink@.
 createSymbolicLink :: RawFilePath -> RawFilePath -> IO ()
-createSymbolicLink file1 file2 =
-  withFilePath file1 $ \s1 ->
-  withFilePath file2 $ \s2 ->
-  throwErrnoPathIfMinus1_ "createSymbolicLink" file2 (c_symlink s1 s2)
+createSymbolicLink name1 name2 =
+  withFilePath name1 $ \s1 ->
+  withFilePath name2 $ \s2 ->
+  throwErrnoTwoPathsIfMinus1_ "createSymbolicLink" name1 name2 (c_symlink s1 s2)
 
 foreign import ccall unsafe "symlink"
   c_symlink :: CString -> CString -> IO CInt
@@ -296,7 +296,7 @@ rename :: RawFilePath -> RawFilePath -> IO ()
 rename name1 name2 =
   withFilePath name1 $ \s1 ->
   withFilePath name2 $ \s2 ->
-  throwErrnoPathIfMinus1_ "rename" name1 (c_rename s1 s2)
+  throwErrnoTwoPathsIfMinus1_ "rename" name1 name2 (c_rename s1 s2)
 
 foreign import ccall unsafe "rename"
    c_rename :: CString -> CString -> IO CInt

--- a/tests/FileStatus.hs
+++ b/tests/FileStatus.hs
@@ -10,6 +10,7 @@ import System.Posix.Directory
 import System.Posix.IO
 import Control.Exception as E
 import Control.Monad
+import Test.Tasty.HUnit
 
 main = do
   cleanup
@@ -70,7 +71,7 @@ testLink = do
   createLink regular hlink_regular
   (fs, _)  <- getStatus regular -- we need to retrieve it again as creating the link causes it to change!
   (fs', ls)  <- getStatus hlink_regular
-  let expected = (
+  snd (statusElements ls) @?= (
                 False, -- isBlockDevice
                 False, -- isCharacterDevice
                 False, -- isNamedPipe
@@ -78,16 +79,8 @@ testLink = do
                 False, -- isDirectory
                 False, -- isSymbolicLink
                 False) -- isSocket
-      actualF  = snd (statusElements ls)
-
-  when (actualF /= expected) $
-    fail "unexpected file status bits for hard link to regular file"
-
-  when (linkCount fs' /= 2) $
-    fail "newly created hard link was expected to contain have a link count of 2"
-
-  when (statusElements fs /= statusElements fs') $
-    fail "status for a file does not match when it's accessed via a link"
+  linkCount fs' == 2 @? "Newly created hard link was expected to have a link count of 2"
+  statusElements fs @?= statusElements fs' -- status for a file should match when accessed via a link
 
 
 cleanup = do


### PR DESCRIPTION
This fixes #60. It builds on #65 (I cherry-picked the commit), while addressing the issues raised there.
