### PR TITLE
Changes for GHC 8.8

### DIFF
--- a/tests/libposix/all.T
+++ b/tests/libposix/all.T
@@ -1,4 +1,4 @@
-test('posix002', [ reqlib('unix'), omit_ways(prof_ways) ],
+test('posix002', [ reqlib('unix'), omit_ways(prof_ways), fragile_for(16550, ['threaded2']) ],
                  compile_and_run, [''])
 
 # Skip on mingw32: assumes existence of 'pwd' and /tmp

--- a/unix.cabal
+++ b/unix.cabal
@@ -70,7 +70,7 @@ library
         buildable: False
 
     build-depends:
-        base        >= 4.5     && < 4.13,
+        base        >= 4.5     && < 4.14,
         bytestring  >= 0.9.2   && < 0.11,
         time        >= 1.2     && < 1.10
 


### PR DESCRIPTION
Bump bound on `base` and mark a fragile test as such.