### PR TITLE
Introduce flag for overall FFI calls safe/unsafe behaviour

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -51,13 +51,20 @@ source-repository head
     type:     git
     location: https://github.com/haskell/unix.git
 
+flag unsafe
+     description: Declare all FFI calls 'unsafe'. This results in faster
+                  performance, but calls that block in the kernel might
+                  result in overly long GC or other hard to debug issues.
+     default:     True
+
 library
     default-language: Haskell2010
+    default-extensions:
+        CPP
+        InterruptibleFFI
     other-extensions:
         CApiFFI
-        CPP
         DeriveDataTypeable
-        InterruptibleFFI
         NondecreasingIndentation
         RankNTypes
         RecordWildCards
@@ -130,6 +137,12 @@ library
         System.Posix.Terminal.Common
 
     ghc-options: -Wall
+
+    cpp-options: -DFFI_UNSAFE=unsafe
+    if flag(unsafe)
+        cpp-options: -DFFI_SAFE=unsafe -DFFI_INTR=unsafe
+    else
+        cpp-options: -DFFI_SAFE=safe -DFFI_INTR=interruptible
 
     include-dirs: include
     includes:


### PR DESCRIPTION
Start of changes for addressing #34. The flag is not used yet, but
will be in future patches.

The idea is that all functions will be changed from `ccall unsafe` to
`ccall FFI_*`, and then this flag denotes whether FFI defines map to the
actual values or all point to old-style/"fast" unsafe calls.

Sending this first to see if we agree on approach for converting the
code.

Signed-off-by: Iustin Pop <iustin@k1024.org>