### PR TITLE
Add some basic type class instances for `OpenMode` and `OpenFileFlags`.

### DIFF
--- a/System/Posix/IO/Common.hsc
+++ b/System/Posix/IO/Common.hsc
@@ -129,6 +129,7 @@ stdOutput  = Fd (#const STDOUT_FILENO)
 stdError   = Fd (#const STDERR_FILENO)
 
 data OpenMode = ReadOnly | WriteOnly | ReadWrite
+              deriving (Show, Eq, Ord)
 
 -- |Correspond to some of the int flags from C's fcntl.h.
 data OpenFileFlags =
@@ -156,6 +157,7 @@ data OpenFileFlags =
                                  --
                                  -- @since 2.8.0.0
  }
+ deriving (Show, Eq, Ord)
 
 
 -- | Default values for the 'OpenFileFlags' type.

--- a/System/Posix/IO/Common.hsc
+++ b/System/Posix/IO/Common.hsc
@@ -129,7 +129,7 @@ stdOutput  = Fd (#const STDOUT_FILENO)
 stdError   = Fd (#const STDERR_FILENO)
 
 data OpenMode = ReadOnly | WriteOnly | ReadWrite
-              deriving (Show, Eq, Ord)
+              deriving (Read, Show, Eq, Ord)
 
 -- |Correspond to some of the int flags from C's fcntl.h.
 data OpenFileFlags =
@@ -157,7 +157,7 @@ data OpenFileFlags =
                                  --
                                  -- @since 2.8.0.0
  }
- deriving (Show, Eq, Ord)
+ deriving (Read, Show, Eq, Ord)
 
 
 -- | Default values for the 'OpenFileFlags' type.

--- a/changelog.md
+++ b/changelog.md
@@ -20,7 +20,7 @@
   * Generalise return type of `exitImmediately` from `ExitCode -> IO ()` to
     `∀a. ExitCode -> IO a` (#130)
     
-  * Add basic type class instances to `OpenFileFlags` and `OpenMode`. (#75, #141)
+  * Add `Read`, `Show`, `Eq`, and `Ord` typeclass instances to `OpenFileFlags` and `OpenMode`. (#75, #141)
 
 ## 2.7.2.2  *May 2017*
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@
 
   * Generalise return type of `exitImmediately` from `ExitCode -> IO ()` to
     `∀a. ExitCode -> IO a` (#130)
+    
+  * Add basic type class instances to `OpenFileFlags` and `OpenMode`. (#75, #141)
 
 ## 2.7.2.2  *May 2017*
 


### PR DESCRIPTION
I've written a few different programs that provide orphan instances for these types, and I think that adding some basic derived instances should be uncontroversial.

Closes #75.