### PR TITLE
Implement BaudRate with PatternSynonyms.

### DIFF
--- a/System/Posix/Terminal/ByteString.hsc
+++ b/System/Posix/Terminal/ByteString.hsc
@@ -1,4 +1,5 @@
 {-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE PatternSynonyms #-}
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
 #else
@@ -44,7 +45,100 @@ module System.Posix.Terminal.ByteString (
   minInput,
   withMinInput,
 
-  BaudRate(..),
+  BaudRate,
+#ifdef B0
+  pattern B0,
+#endif
+#ifdef B50
+  pattern B50,
+#endif
+#ifdef B75
+  pattern B75,
+#endif
+#ifdef B110
+  pattern B110,
+#endif
+#ifdef B134
+  pattern B134,
+#endif
+#ifdef B150
+  pattern B150,
+#endif
+#ifdef B200
+  pattern B200,
+#endif
+#ifdef B300
+  pattern B300,
+#endif
+#ifdef B600
+  pattern B600,
+#endif
+#ifdef B1200
+  pattern B1200,
+#endif
+#ifdef B1800
+  pattern B1800,
+#endif
+#ifdef B2400
+  pattern B2400,
+#endif
+#ifdef B4800
+  pattern B4800,
+#endif
+#ifdef B9600
+  pattern B9600,
+#endif
+#ifdef B19200
+  pattern B19200,
+#endif
+#ifdef B38400
+  pattern B38400,
+#endif
+#ifdef B57600
+  pattern B57600,
+#endif
+#ifdef B115200
+  pattern B115200,
+#endif
+#ifdef B230400
+  pattern B230400,
+#endif
+#ifdef B460800
+  pattern B460800,
+#endif
+#ifdef B500000
+  pattern B500000,
+#endif
+#ifdef B576000
+  pattern B576000,
+#endif
+#ifdef B921600
+  pattern B921600,
+#endif
+#ifdef B1000000
+  pattern B1000000,
+#endif
+#ifdef B1152000
+  pattern B1152000,
+#endif
+#ifdef B1500000
+  pattern B1500000,
+#endif
+#ifdef B2000000
+  pattern B2000000,
+#endif
+#ifdef B2500000
+  pattern B2500000,
+#endif
+#ifdef B3000000
+  pattern B3000000,
+#endif
+#ifdef B3500000
+  pattern B3500000,
+#endif
+#ifdef B4000000
+  pattern B4000000,
+#endif
   inputSpeed,
   withInputSpeed,
   outputSpeed,

--- a/System/Posix/Terminal/Common.hsc
+++ b/System/Posix/Terminal/Common.hsc
@@ -1,4 +1,5 @@
 {-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE Trustworthy #-}
 
 -----------------------------------------------------------------------------
@@ -48,7 +49,100 @@ module System.Posix.Terminal.Common (
   minInput,
   withMinInput,
 
-  BaudRate(..),
+  BaudRate,
+#ifdef B0
+  pattern B0,
+#endif
+#ifdef B50
+  pattern B50,
+#endif
+#ifdef B75
+  pattern B75,
+#endif
+#ifdef B110
+  pattern B110,
+#endif
+#ifdef B134
+  pattern B134,
+#endif
+#ifdef B150
+  pattern B150,
+#endif
+#ifdef B200
+  pattern B200,
+#endif
+#ifdef B300
+  pattern B300,
+#endif
+#ifdef B600
+  pattern B600,
+#endif
+#ifdef B1200
+  pattern B1200,
+#endif
+#ifdef B1800
+  pattern B1800,
+#endif
+#ifdef B2400
+  pattern B2400,
+#endif
+#ifdef B4800
+  pattern B4800,
+#endif
+#ifdef B9600
+  pattern B9600,
+#endif
+#ifdef B19200
+  pattern B19200,
+#endif
+#ifdef B38400
+  pattern B38400,
+#endif
+#ifdef B57600
+  pattern B57600,
+#endif
+#ifdef B115200
+  pattern B115200,
+#endif
+#ifdef B230400
+  pattern B230400,
+#endif
+#ifdef B460800
+  pattern B460800,
+#endif
+#ifdef B500000
+  pattern B500000,
+#endif
+#ifdef B576000
+  pattern B576000,
+#endif
+#ifdef B921600
+  pattern B921600,
+#endif
+#ifdef B1000000
+  pattern B1000000,
+#endif
+#ifdef B1152000
+  pattern B1152000,
+#endif
+#ifdef B1500000
+  pattern B1500000,
+#endif
+#ifdef B2000000
+  pattern B2000000,
+#endif
+#ifdef B2500000
+  pattern B2500000,
+#endif
+#ifdef B3000000
+  pattern B3000000,
+#endif
+#ifdef B3500000
+  pattern B3500000,
+#endif
+#ifdef B4000000
+  pattern B4000000,
+#endif
   inputSpeed,
   withInputSpeed,
   outputSpeed,
@@ -74,6 +168,7 @@ module System.Posix.Terminal.Common (
 
 import Data.Bits
 import Data.Char
+import Data.Coerce
 import Foreign.C.Error ( throwErrnoIfMinus1, throwErrnoIfMinus1_ )
 import Foreign.C.Types
 import Foreign.ForeignPtr ( ForeignPtr, withForeignPtr, mallocForeignPtrBytes )
@@ -352,40 +447,132 @@ withMinInput termios count = unsafePerformIO $ do
     let c_cc = (#ptr struct termios, c_cc) p
     pokeElemOff c_cc (#const VMIN) (fromIntegral count :: CCc)
 
-data BaudRate
-  -- These are the standard rates stipulated by POSIX:
-  = B0
-  | B50
-  | B75
-  | B110
-  | B134
-  | B150
-  | B200
-  | B300
-  | B600
-  | B1200
-  | B1800
-  | B2400
-  | B4800
-  | B9600
-  | B19200
-  | B38400
-  -- These are non-standard rates that are often present on modern Unixes:
-  | B57600
-  | B115200
-  | B230400
-  | B460800
-  | B500000
-  | B576000
-  | B921600
-  | B1000000
-  | B1152000
-  | B1500000
-  | B2000000
-  | B2500000
-  | B3000000
-  | B3500000
-  | B4000000
+newtype BaudRate = BaudRate CSpeed
+
+#ifdef B0
+pattern B0 :: BaudRate
+pattern B0 = BaudRate (#const B0)
+#endif
+#ifdef B50
+pattern B50 :: BaudRate
+pattern B50 = BaudRate (#const B50)
+#endif
+#ifdef B75
+pattern B75 :: BaudRate
+pattern B75 = BaudRate (#const B75)
+#endif
+#ifdef B110
+pattern B110 :: BaudRate
+pattern B110 = BaudRate (#const B110)
+#endif
+#ifdef B134
+pattern B134 :: BaudRate
+pattern B134 = BaudRate (#const B134)
+#endif
+#ifdef B150
+pattern B150 :: BaudRate
+pattern B150 = BaudRate (#const B150)
+#endif
+#ifdef B200
+pattern B200 :: BaudRate
+pattern B200 = BaudRate (#const B200)
+#endif
+#ifdef B300
+pattern B300 :: BaudRate
+pattern B300 = BaudRate (#const B300)
+#endif
+#ifdef B600
+pattern B600 :: BaudRate
+pattern B600 = BaudRate (#const B600)
+#endif
+#ifdef B1200
+pattern B1200 :: BaudRate
+pattern B1200 = BaudRate (#const B1200)
+#endif
+#ifdef B1800
+pattern B1800 :: BaudRate
+pattern B1800 = BaudRate (#const B1800)
+#endif
+#ifdef B2400
+pattern B2400 :: BaudRate
+pattern B2400 = BaudRate (#const B2400)
+#endif
+#ifdef B4800
+pattern B4800 :: BaudRate
+pattern B4800 = BaudRate (#const B4800)
+#endif
+#ifdef B9600
+pattern B9600 :: BaudRate
+pattern B9600 = BaudRate (#const B9600)
+#endif
+#ifdef B19200
+pattern B19200 :: BaudRate
+pattern B19200 = BaudRate (#const B19200)
+#endif
+#ifdef B38400
+pattern B38400 :: BaudRate
+pattern B38400 = BaudRate (#const B38400)
+#endif
+#ifdef B57600
+pattern B57600 :: BaudRate
+pattern B57600 = BaudRate (#const B57600)
+#endif
+#ifdef B115200
+pattern B115200 :: BaudRate
+pattern B115200 = BaudRate (#const B115200)
+#endif
+#ifdef B230400
+pattern B230400 :: BaudRate
+pattern B230400 = BaudRate (#const B230400)
+#endif
+#ifdef B460800
+pattern B460800 :: BaudRate
+pattern B460800 = BaudRate (#const B460800)
+#endif
+#ifdef B500000
+pattern B500000 :: BaudRate
+pattern B500000 = BaudRate (#const B500000)
+#endif
+#ifdef B576000
+pattern B576000 :: BaudRate
+pattern B576000 = BaudRate (#const B576000)
+#endif
+#ifdef B921600
+pattern B921600 :: BaudRate
+pattern B921600 = BaudRate (#const B921600)
+#endif
+#ifdef B1000000
+pattern B1000000 :: BaudRate
+pattern B1000000 = BaudRate (#const B1000000)
+#endif
+#ifdef B1152000
+pattern B1152000 :: BaudRate
+pattern B1152000 = BaudRate (#const B1152000)
+#endif
+#ifdef B1500000
+pattern B1500000 :: BaudRate
+pattern B1500000 = BaudRate (#const B1500000)
+#endif
+#ifdef B2000000
+pattern B2000000 :: BaudRate
+pattern B2000000 = BaudRate (#const B2000000)
+#endif
+#ifdef B2500000
+pattern B2500000 :: BaudRate
+pattern B2500000 = BaudRate (#const B2500000)
+#endif
+#ifdef B3000000
+pattern B3000000 :: BaudRate
+pattern B3000000 = BaudRate (#const B3000000)
+#endif
+#ifdef B3500000
+pattern B3500000 :: BaudRate
+pattern B3500000 = BaudRate (#const B3500000)
+#endif
+#ifdef B4000000
+pattern B4000000 :: BaudRate
+pattern B4000000 = BaudRate (#const B4000000)
+#endif
 
 inputSpeed :: TerminalAttributes -> BaudRate
 inputSpeed termios = unsafePerformIO $ do
@@ -581,119 +768,61 @@ cc2Word Stop      = (#const VSTOP)
 -- Convert Haskell BaudRate to unsigned integral type (Word)
 
 baud2Word :: BaudRate -> CSpeed
-baud2Word B0 = (#const B0)
-baud2Word B50 = (#const B50)
-baud2Word B75 = (#const B75)
-baud2Word B110 = (#const B110)
-baud2Word B134 = (#const B134)
-baud2Word B150 = (#const B150)
-baud2Word B200 = (#const B200)
-baud2Word B300 = (#const B300)
-baud2Word B600 = (#const B600)
-baud2Word B1200 = (#const B1200)
-baud2Word B1800 = (#const B1800)
-baud2Word B2400 = (#const B2400)
-baud2Word B4800 = (#const B4800)
-baud2Word B9600 = (#const B9600)
-baud2Word B19200 = (#const B19200)
-baud2Word B38400 = (#const B38400)
-#ifdef B57600
-baud2Word B57600 = (#const B57600)
-#else
-baud2Word B57600 = error "B57600 not available on this system"
-#endif
-#ifdef B115200
-baud2Word B115200 = (#const B115200)
-#else
-baud2Word B115200 = error "B115200 not available on this system"
-#endif
-#ifdef B230400
-baud2Word B230400 = (#const B230400)
-#else
-baud2Word B230400 = error "B230400 not available on this system"
-#endif
-#ifdef B460800
-baud2Word B460800 = (#const B460800)
-#else
-baud2Word B460800 = error "B460800 not available on this system"
-#endif
-#ifdef B500000
-baud2Word B500000 = (#const B500000)
-#else
-baud2Word B500000 = error "B500000 not available on this system"
-#endif
-#ifdef B576000
-baud2Word B576000 = (#const B576000)
-#else
-baud2Word B576000 = error "B576000 not available on this system"
-#endif
-#ifdef B921600
-baud2Word B921600 = (#const B921600)
-#else
-baud2Word B921600 = error "B921600 not available on this system"
-#endif
-#ifdef B1000000
-baud2Word B1000000 = (#const B1000000)
-#else
-baud2Word B1000000 = error "B1000000 not available on this system"
-#endif
-#ifdef B1152000
-baud2Word B1152000 = (#const B1152000)
-#else
-baud2Word B1152000 = error "B1152000 not available on this system"
-#endif
-#ifdef B1500000
-baud2Word B1500000 = (#const B1500000)
-#else
-baud2Word B1500000 = error "B1500000 not available on this system"
-#endif
-#ifdef B2000000
-baud2Word B2000000 = (#const B2000000)
-#else
-baud2Word B2000000 = error "B2000000 not available on this system"
-#endif
-#ifdef B2500000
-baud2Word B2500000 = (#const B2500000)
-#else
-baud2Word B2500000 = error "B2500000 not available on this system"
-#endif
-#ifdef B3000000
-baud2Word B3000000 = (#const B3000000)
-#else
-baud2Word B3000000 = error "B3000000 not available on this system"
-#endif
-#ifdef B3500000
-baud2Word B3500000 = (#const B3500000)
-#else
-baud2Word B3500000 = error "B3500000 not available on this system"
-#endif
-#ifdef B4000000
-baud2Word B4000000 = (#const B4000000)
-#else
-baud2Word B4000000 = error "B4000000 not available on this system"
-#endif
+baud2Word = coerce
 
 -- And convert a word back to a baud rate
 -- We really need some cpp macros here.
 
 word2Baud :: CSpeed -> BaudRate
 word2Baud x = case x of
+#ifdef B0
     (#const B0) -> B0
+#endif
+#ifdef B50
     (#const B50) -> B50
+#endif
+#ifdef B75
     (#const B75) -> B75
+#endif
+#ifdef B110
     (#const B110) -> B110
+#endif
+#ifdef B134
     (#const B134) -> B134
+#endif
+#ifdef B150
     (#const B150) -> B150
+#endif
+#ifdef B200
     (#const B200) -> B200
+#endif
+#ifdef B300
     (#const B300) -> B300
+#endif
+#ifdef B600
     (#const B600) -> B600
+#endif
+#ifdef B1200
     (#const B1200) -> B1200
+#endif
+#ifdef B1800
     (#const B1800) -> B1800
+#endif
+#ifdef B2400
     (#const B2400) -> B2400
+#endif
+#ifdef B4800
     (#const B4800) -> B4800
+#endif
+#ifdef B9600
     (#const B9600) -> B9600
+#endif
+#ifdef B19200
     (#const B19200) -> B19200
+#endif
+#ifdef B38400
     (#const B38400) -> B38400
+#endif
 #ifdef B57600
     (#const B57600) -> B57600
 #endif


### PR DESCRIPTION
This is a sketch of a new way of handling baud rates. The idea is to make `BaudRate` an opaque type, and provide pattern synonyms based on the availability of baud rate macros from the local termios header. There are two downsides to this approach:

- Older GHC versions don't support `-XPatternSynonyms`.
- The only way to write a total function of `BaudRate` is to use `baud2Word`.

I'm responsible for lots of Haskell code wrapping C APIs, and this approach seems to work well. The [gl package](https://hackage.haskell.org/package/gl) uses the same approach for handling constants from C headers.