### PR TITLE
Create DirStream using an Fd, using fdopendir

### DIFF
--- a/System/Posix/Directory.hsc
+++ b/System/Posix/Directory.hsc
@@ -34,6 +34,7 @@ module System.Posix.Directory (
    -- * Reading directories
    DirStream,
    openDirStream,
+   fdOpenDirStream,
    readDirStream,
    rewindDirStream,
    closeDirStream,
@@ -83,6 +84,16 @@ openDirStream name =
 
 foreign import capi unsafe "HsUnix.h opendir"
    c_opendir :: CString  -> IO (Ptr CDir)
+
+-- | @fdOpenDirStream dir@ calls @fdopendir@ to obtain a
+--   directory stream for @dirfd@.
+fdOpenDirStream :: Fd -> IO DirStream
+fdOpenDirStream (Fd fd) = do
+  dirp <- throwErrnoIfNullRetry "fdOpenDirStream" $ c_fdopendir fd
+  return (DirStream dirp)
+
+foreign import capi unsafe "HsUnix.h fdopendir"
+   c_fdopendir :: CInt  -> IO (Ptr CDir)
 
 -- | @readDirStream dp@ calls @readdir@ to obtain the
 --   next directory entry (@struct dirent@) for the open directory


### PR DESCRIPTION
Not an interesting change, but I have a system that's passing Fds around through AF_UNIX connections, and being able to pass a directory Fd through that would be much simpler for me than passing around the directory contents. I'm hoping this isn't too controversial :)

A quick example of how this can be used would be:
```
Prelude System.Posix> :m +System.Posix.IO
Prelude System.Posix.IO System.Posix> :m +System.Posix.Directory
Prelude System.Posix.IO System.Posix.Directory System.Posix> fd <- openFd "/" ReadOnly defaultFileFlags
Prelude System.Posix.IO System.Posix.Directory System.Posix> dir <- fdOpenDirStream fd
Prelude System.Posix.IO System.Posix.Directory System.Posix> readDirStream dir
"."
```