### PR TITLE
 Support base-4.14.0.0 and time-1.10

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -73,7 +73,7 @@ library
     build-depends:
         base        >= 4.5     && < 4.15,
         bytestring  >= 0.9.2   && < 0.11,
-        time        >= 1.2     && < 1.10
+        time        >= 1.2     && < 1.11
 
     exposed-modules:
         System.Posix

--- a/unix.cabal
+++ b/unix.cabal
@@ -71,7 +71,7 @@ library
         buildable: False
 
     build-depends:
-        base        >= 4.5     && < 4.14,
+        base        >= 4.5     && < 4.15,
         bytestring  >= 0.9.2   && < 0.11,
         time        >= 1.2     && < 1.10
 


### PR DESCRIPTION
Why? Support the current base version.

Configured/built/install locally using: 
ghc-8.10.1
cabal-3.2.0.0
base-4.14.00
with/
 autoreconf v2.69 to build config script. 