### PR TITLE
Bump base upper bound to 4.16

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -62,7 +62,7 @@ library
         buildable: False
 
     build-depends:
-        base        >= 4.5     && < 4.16,
+        base        >= 4.5     && < 4.17,
         bytestring  >= 0.9.2   && < 0.11,
         time        >= 1.2     && < 1.10
 


### PR DESCRIPTION
~also includes a few patches that were used in GHC HEAD's mirror and I had to rebase~

Context: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4082#note_300462