### PR TITLE
Bytestring 11 support

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -72,7 +72,7 @@ library
 
     build-depends:
         base        >= 4.5     && < 4.14,
-        bytestring  >= 0.9.2   && < 0.11,
+        bytestring  >= 0.9.2   && < 0.12,
         time        >= 1.2     && < 1.10
 
     exposed-modules:


### PR DESCRIPTION
@hvr this should be insta-merge, just bumps the version on `bytestring`. See #160. 

I'm blocked on this due to `tasty`'s `unix` dependency. 