### PR TITLE
Allow bytestring-0.11 in 2.7 branch

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -63,7 +63,7 @@ library
 
     build-depends:
         base        >= 4.5     && < 4.17,
-        bytestring  >= 0.9.2   && < 0.11,
+        bytestring  >= 0.9.2   && < 0.12,
         time        >= 1.2     && < 1.12
 
     exposed-modules:


### PR DESCRIPTION
Backports #162 to 2.7 branch. GHC needs a commit to bump `unix` submodule, a [Hackage revision](https://hackage.haskell.org/package/unix-2.7.2.2/revisions/) is not enough.