### PR TITLE
Thread safety of passwd/group lookups

### DIFF
--- a/System/Posix/User.hsc
+++ b/System/Posix/User.hsc
@@ -208,7 +208,7 @@ getGroupEntryForID gid =
    doubleAllocWhileERANGE "getGroupEntryForID" "group" grBufSize unpackGroupEntry $
      c_getgrgid_r gid pgr
 
-foreign import capi unsafe "HsUnix.h getgrgid_r"
+foreign import capi safe "HsUnix.h getgrgid_r"
   c_getgrgid_r :: CGid -> Ptr CGroup -> CString
                  -> CSize -> Ptr (Ptr CGroup) -> IO CInt
 #else
@@ -227,7 +227,7 @@ getGroupEntryForName name =
       doubleAllocWhileERANGE "getGroupEntryForName" "group" grBufSize unpackGroupEntry $
         c_getgrnam_r pstr pgr
 
-foreign import capi unsafe "HsUnix.h getgrnam_r"
+foreign import capi safe "HsUnix.h getgrnam_r"
   c_getgrnam_r :: CString -> Ptr CGroup -> CString
                  -> CSize -> Ptr (Ptr CGroup) -> IO CInt
 #else
@@ -255,12 +255,9 @@ getAllGroupEntries =
                      else do thisentry <- unpackGroupEntry ppw
                              worker (thisentry : accum)
 
-foreign import ccall unsafe "getgrent"
-  c_getgrent :: IO (Ptr CGroup)
-foreign import ccall unsafe "setgrent"
-  c_setgrent :: IO ()
-foreign import ccall unsafe "endgrent"
-  c_endgrent :: IO ()
+foreign import ccall safe "getgrent" c_getgrent :: IO (Ptr CGroup)
+foreign import ccall safe "setgrent" c_setgrent :: IO ()
+foreign import ccall safe "endgrent" c_endgrent :: IO ()
 #else
 getAllGroupEntries = error "System.Posix.User.getAllGroupEntries: not supported"
 #endif
@@ -317,7 +314,7 @@ getUserEntryForID uid =
     doubleAllocWhileERANGE "getUserEntryForID" "user" pwBufSize unpackUserEntry $
       c_getpwuid_r uid ppw
 
-foreign import capi unsafe "HsUnix.h getpwuid_r"
+foreign import capi safe "HsUnix.h getpwuid_r"
   c_getpwuid_r :: CUid -> Ptr CPasswd ->
                         CString -> CSize -> Ptr (Ptr CPasswd) -> IO CInt
 #else
@@ -336,7 +333,7 @@ getUserEntryForName name =
       doubleAllocWhileERANGE "getUserEntryForName" "user" pwBufSize unpackUserEntry $
         c_getpwnam_r pstr ppw
 
-foreign import capi unsafe "HsUnix.h getpwnam_r"
+foreign import capi safe "HsUnix.h getpwnam_r"
   c_getpwnam_r :: CString -> Ptr CPasswd
                -> CString -> CSize -> Ptr (Ptr CPasswd) -> IO CInt
 #else
@@ -358,12 +355,9 @@ getAllUserEntries =
                      else do thisentry <- unpackUserEntry ppw
                              worker (thisentry : accum)
 
-foreign import capi unsafe "HsUnix.h getpwent"
-  c_getpwent :: IO (Ptr CPasswd)
-foreign import capi unsafe "HsUnix.h setpwent"
-  c_setpwent :: IO ()
-foreign import capi unsafe "HsUnix.h endpwent"
-  c_endpwent :: IO ()
+foreign import ccall safe "getpwent" c_getpwent :: IO (Ptr CPasswd)
+foreign import ccall safe "setpwent" c_setpwent :: IO ()
+foreign import ccall safe "endpwent" c_endpwent :: IO ()
 #else
 getAllUserEntries = error "System.Posix.User.getAllUserEntries: not supported"
 #endif

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,18 @@
 
 ## 2.8.0.0 *UNRELEASED*
 
+  * Deal with FreeBSD getpwnam_r(3), ... thread safety.  On FreeBSD these
+    are not in fact safe for overlapped execution with a sequence of
+    getpwent(3) or getgrent(3) calls when multiple "green" threads share
+    the same underlying OS thread.  The *ent(3) calls now run in bound
+    threads or else locks are used to avoid overlapped execution.
+
+  * Make passwd/group FFI functions "safe", these are not low-latency APIs.
+
+  * Drop support for non-thread-safe getpwnam(3) and getpwuid(3).  All
+    supported platforms have getpwnam_r(3) and getpwuid_r(3).  This was
+    already the case for the getgr(nam|gid) calls.
+
   * Added terminal output flags to `System.Posix.Terminal.Common.TerminalMode`
 
         IXANY, ONLCR, OCRNL, ONOCR, ONLRET, OFDEL, OFILL, NLDLY(NL0,NL1),


### PR DESCRIPTION
- Simplify target platform assumptions: either getpwnam_r(3)
  and getpwuid_r(3) exist, or we don't support password lookups.
  The legacy non-thread-safe variants should not be needed on
  any supported platforms.

- Change the passwd/group FFI glue functions from "unsafe" to
  "safe".  These are not low-latency APIs.

- Then, sadly add some complexity to the implementation, because
  on FreeBSD systems the get(pw|gr)(nam|[ug]id)_r(3)
  "thread-safe" functions are only safe in 1-to-1 thread models.
  They share the thread-specific open file handle with calls
  from get(gr|pw)ent(3), breaking Haskell's sharing of OS threads
  for multiple "green" threads.

  The work-around is to use bound threads for the "*ent(3)" functions
  on FreeBSD systems when in the threaded RTS, and otherwise use locks
  to serialise all passwd/group file access.

  Linux, MacOS, NetBSD and OpenBSD systems don't appear to require the same
  work-around, as they don't share the FreeBSD passwd "compat" and getgrent(3),
  [bugs](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=252094)
