### PR TITLE
getEnvDefault: Make the fallback explicit in docs

### DIFF
--- a/System/Posix/DynamicLinker.hsc
+++ b/System/Posix/DynamicLinker.hsc
@@ -52,14 +52,12 @@ import System.Posix.DynamicLinker.Prim
 #include "HsUnix.h"
 
 import Control.Exception        ( bracket )
-import Control.Monad    ( liftM )
 import Foreign
 import System.Posix.Internals ( withFilePath )
 
 dlopen :: FilePath -> [RTLDFlags] -> IO DL
-dlopen path flags = do
-  withFilePath path $ \ p -> do
-    liftM DLHandle $ throwDLErrorIf "dlopen" (== nullPtr) $ c_dlopen p (packRTLDFlags flags)
+dlopen path flags = withFilePath path $ \p -> DLHandle <$>
+  throwDLErrorIf "dlopen" (== nullPtr) (c_dlopen p (packRTLDFlags flags))
 
 withDL :: FilePath -> [RTLDFlags] -> (DL -> IO a) -> IO a
 withDL file flags f = bracket (dlopen file flags) (dlclose) f

--- a/System/Posix/DynamicLinker/ByteString.hsc
+++ b/System/Posix/DynamicLinker/ByteString.hsc
@@ -53,14 +53,12 @@ import System.Posix.DynamicLinker.Prim
 #include "HsUnix.h"
 
 import Control.Exception        ( bracket )
-import Control.Monad    ( liftM )
 import Foreign
 import System.Posix.ByteString.FilePath
 
 dlopen :: RawFilePath -> [RTLDFlags] -> IO DL
-dlopen path flags = do
-  withFilePath path $ \ p -> do
-    liftM DLHandle $ throwDLErrorIf "dlopen" (== nullPtr) $ c_dlopen p (packRTLDFlags flags)
+dlopen path flags = withFilePath path $ \p -> DLHandle <$>
+  throwDLErrorIf "dlopen" (== nullPtr) (c_dlopen p (packRTLDFlags flags))
 
 withDL :: RawFilePath -> [RTLDFlags] -> (DL -> IO a) -> IO a
 withDL file flags f = bracket (dlopen file flags) (dlclose) f

--- a/System/Posix/Env.hsc
+++ b/System/Posix/Env.hsc
@@ -46,7 +46,7 @@ getEnv ::
 getEnv name = do
   litstring <- withFilePath name c_getenv
   if litstring /= nullPtr
-     then liftM Just $ peekFilePath litstring
+     then Just <$> peekFilePath litstring
      else return Nothing
 
 -- |'getEnvDefault' is a wrapper around 'getEnv' where the
@@ -57,7 +57,7 @@ getEnvDefault ::
   String    {- ^ variable name                    -} ->
   String    {- ^ fallback value                   -} ->
   IO String {- ^ variable value or fallback value -}
-getEnvDefault name fallback = liftM (fromMaybe fallback) (getEnv name)
+getEnvDefault name fallback = fromMaybe fallback <$> getEnv name
 
 foreign import ccall unsafe "getenv"
    c_getenv :: CString -> IO CString


### PR DESCRIPTION
Also replace calls to `liftM` in the same module with <$> which is now in
Prelude.

Closes: #61