### PR TITLE
Fixes #35: fd{Read,Write} with ByteString payload

### DIFF
--- a/System/Posix/IO.hsc
+++ b/System/Posix/IO.hsc
@@ -35,6 +35,7 @@ module System.Posix.IO (
     -- EAGAIN exceptions may occur for non-blocking IO!
 
     fdRead, fdWrite,
+    fdReadBytes, fdWriteBytes,
     fdReadBuf, fdWriteBuf,
 
     -- ** Seeking

--- a/System/Posix/IO/ByteString.hsc
+++ b/System/Posix/IO/ByteString.hsc
@@ -35,6 +35,7 @@ module System.Posix.IO.ByteString (
     -- EAGAIN exceptions may occur for non-blocking IO!
 
     fdRead, fdWrite,
+    fdReadBytes, fdWriteBytes,
     fdReadBuf, fdWriteBuf,
 
     -- ** Seeking


### PR DESCRIPTION
This commit addes two new functions: fdReadBytes and fdWriteBytes.
They are like fdRead and fdWrite respectively but instead of
reading/writing String they use ByteStrings.

Fixes #35 