### PR TITLE
derive Read, Show, Eq, and Ord instances for BaudRate

### DIFF
--- a/System/Posix/Terminal/Common.hsc
+++ b/System/Posix/Terminal/Common.hsc
@@ -386,6 +386,7 @@ data BaudRate
   | B3000000
   | B3500000
   | B4000000
+  deriving (Read, Show, Eq, Ord)
 
 inputSpeed :: TerminalAttributes -> BaudRate
 inputSpeed termios = unsafePerformIO $ do

--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,8 @@
     
   * Add `Read`, `Show`, `Eq`, and `Ord` typeclass instances to `OpenFileFlags` and `OpenMode`. (#75, #141)
 
+  * Derive `Read`, `Show`, `Eq`, and `Ord` typeclass instances for `BaudeRate`. (#191)
+
 ## 2.7.2.2  *May 2017*
 
   * Bundled with GHC 8.2.1


### PR DESCRIPTION
Derive `Read`, `Show`, `Eq`, and `Ord` instances for `BaudRate`. It would be useful to have these instances for [serialport](https://github.com/standardsemiconductor/serialport).