### PR TITLE
v2.7: Bump time upper bound to allow 1.12

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -64,7 +64,7 @@ library
     build-depends:
         base        >= 4.5     && < 4.17,
         bytestring  >= 0.9.2   && < 0.12,
-        time        >= 1.2     && < 1.12
+        time        >= 1.2     && < 1.13
 
     exposed-modules:
         System.Posix


### PR DESCRIPTION
In service of [GHC #20547](https://gitlab.haskell.org/ghc/ghc/-/issues/20547).