### PR TITLE
Update CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,9 @@
+freebsd_instance:
+  image_family: freebsd-13-0
+
+task:
+  install_script: pkg install -y ghc hs-cabal-install git autoconf
+  script:
+    - cabal update
+    - autoreconf -i
+    - cabal test --test-show-details=direct

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: ci
 on:
-  push:
-    branches:
-      - master
-      - 2.7
-  pull_request: {}
+  - push
+  - pull_request
 
 defaults:
   run:
@@ -17,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        ghc: ['9.0', '8.10', '8.8', '8.6', '8.4', '8.2']
+        ghc: ['9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2']
     steps:
     - uses: actions/checkout@v2
     - uses: haskell/actions/setup@v1
@@ -33,31 +30,95 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.ghc }}
     - name: Build
       run: |
+        cabal --version
+        cabal update
+        autoreconf --version
         autoreconf -i
         cabal sdist -z -o .
         cabal get unix-*.tar.gz
         cd unix-*/
-        cabal update
         cabal test all --test-show-details=direct
     - name: Haddock
       run: cabal haddock
 
-  build-freebsd:
-    needs: build
-    # See https://github.com/vmactions/freebsd-vm#under-the-hood.
-    runs-on: macos-latest
+  centos7:
+    runs-on: ubuntu-latest
+    container:
+      image: centos:7
+    steps:
+    - name: Install
+      run: |
+        yum install -y gcc gmp gmp-devel make ncurses ncurses-compat-libs xz perl autoconf
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
+    - uses: actions/checkout@v2
+    - name: Test
+      run: |
+        source ~/.ghcup/env
+        cabal --version
+        cabal update
+        autoreconf --version
+        autoreconf -i
+        cabal test all --test-show-details=direct
+
+  fedora34:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:34
+    steps:
+    - name: Install
+      run: |
+        dnf install -y gcc gmp gmp-devel make ncurses ncurses-compat-libs xz perl autoconf
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
+    - uses: actions/checkout@v2
+    - name: Test
+      run: |
+        source ~/.ghcup/env
+        cabal --version
+        cabal update
+        autoreconf --version
+        autoreconf -i
+        cabal test all --test-show-details=direct
+
+  i386:
+    runs-on: ubuntu-latest
+    container:
+      image: i386/ubuntu:bionic
+    steps:
+    - name: Install
+      run: |
+        apt-get update -y
+        apt-get install -y autoconf build-essential zlib1g-dev libgmp-dev curl
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
+    - uses: actions/checkout@v1
+    - name: Test
+      run: |
+        source ~/.ghcup/env
+        cabal --version
+        cabal update
+        autoreconf --version
+        autoreconf -i
+        cabal v2-test --constraint 'optparse-applicative -process' --constraint 'QuickCheck +old-random' --constraint 'tasty -unix' all
+
+  arm:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['armv7', 'aarch64']
     steps:
     - uses: actions/checkout@v2
-    - name: Build
-      id: build-freebsd
-      uses: vmactions/freebsd-vm@v0.1.4
+    - uses: uraimo/run-on-arch-action@v2.1.1
+      timeout-minutes: 60
       with:
-        usesh: true
-        prepare: pkg install -y ghc hs-cabal-install git autoconf
+        arch: ${{ matrix.arch }}
+        distro: ubuntu20.04
+        githubToken: ${{ github.token }}
+        install: |
+          apt-get update -y
+          apt-get install -y ghc cabal-install autoconf
         run: |
-          autoreconf -i
-          cabal sdist -z -o .
-          cabal get unix-*.tar.gz
-          cd unix-*/
+          cabal --version
           cabal update
-          cabal test all --test-show-details=direct
+          autoreconf --version
+          autoreconf -i
+          cabal v2-test --constraint 'optparse-applicative -process' --constraint 'QuickCheck +old-random' --constraint 'tasty -unix' all

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -171,7 +171,7 @@ posix002 :: TestTree
 posix002 = testCase "posix002" $ do
   actual <- captureStdout $
     executeFile "printenv" True [] (Just [("ONE","1"),("TWO","2")])
-  actual @?= "ONE=1\nTWO=2\n"
+  sort (lines actual) @?= ["ONE=1", "TWO=2"]
 
 posix005 :: TestTree
 posix005 = testCase "posix005" $ do


### PR DESCRIPTION
Replace FreeBSD build, add CentOS build, i386 build, arm (32 + 64 bits) build.

@hs-viktor this fails on ARM
https://github.com/haskell/unix/blob/9c90c34017f3394076c307932ef900a8abeca67f/tests/Test.hs#L170-L174
with 
```
  posix002:             FAIL (0.04s)
    tests/Test.hs:174:
    expected: "ONE=1\nTWO=2\n"
     but got: "TWO=2\nONE=1\n"
    Use -p '/posix002/' to rerun this test only.
```
Is it acceptable?