### PR TITLE
Remove buildable check based on dlfcn.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,10 +11,6 @@ AC_USE_SYSTEM_EXTENSIONS
 
 AC_CONFIG_HEADERS([include/HsUnixConfig.h])
 
-# Is this a Unix system?
-AC_CHECK_HEADER([dlfcn.h], [BUILD_PACKAGE_BOOL=True], [BUILD_PACKAGE_BOOL=False])
-AC_SUBST([BUILD_PACKAGE_BOOL])
-
 AC_C_CONST
 
 dnl ** Enable large file support.  NB. do this before testing the type of

--- a/unix.buildinfo.in
+++ b/unix.buildinfo.in
@@ -1,3 +1,2 @@
-buildable: @BUILD_PACKAGE_BOOL@
 extra-libraries: @EXTRA_LIBS@
 install-includes: HsUnixConfig.h


### PR DESCRIPTION
This PR is a predecessor to #205. We shall no longer deny building for platforms lacking `dlfcn.h`, but rely on fine-grained checks on individual interfaces instead.