### PR TITLE
Make maintainers explicit, fixes #215

### DIFF
--- a/cabal.project.wasm32-wasi
+++ b/cabal.project.wasm32-wasi
@@ -4,3 +4,5 @@ package unix
   ghc-options: -Wno-unused-imports
 
 write-ghc-environment-files: always
+
+allow-newer: all:base

--- a/unix.cabal
+++ b/unix.cabal
@@ -5,7 +5,7 @@ version:        2.8.0.0
 
 license:        BSD3
 license-file:   LICENSE
-maintainer:     libraries@haskell.org
+maintainer:     Julian Ospald <hasufell@posteo.de>, Viktor Dukhovni <ietf-dane@dukhovni.org>, Andrew Lelechenko <andrew.lelechenko@gmail.com>
 homepage:       https://github.com/haskell/unix
 bug-reports:    https://github.com/haskell/unix/issues
 synopsis:       POSIX functionality


### PR DESCRIPTION
Not sure how a list of emails shows up on hackage, but `cabal check` says this is ok.
