### PR TITLE
Fix 'semTrywait: invalid argument (Bad file descriptor)' wrt #218

### DIFF
--- a/System/Posix/Semaphore.hsc
+++ b/System/Posix/Semaphore.hsc
@@ -1,4 +1,5 @@
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE CApiFFI #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.Posix.Semaphore
@@ -110,18 +111,18 @@ semGetValue_ sem ptr = do throwErrnoIfMinus1Retry_ "semGetValue" $
                           cint <- peek ptr
                           return $ fromEnum cint
 
-foreign import ccall safe "sem_open"
+foreign import capi safe "semaphore.h sem_open"
         sem_open :: CString -> CInt -> CMode -> CUInt -> IO (Ptr ())
-foreign import ccall safe "sem_close"
+foreign import capi safe "semaphore.h sem_close"
         sem_close :: Ptr () -> IO CInt
-foreign import ccall safe "sem_unlink"
+foreign import capi safe "semaphore.h sem_unlink"
         sem_unlink :: CString -> IO CInt
 
-foreign import ccall safe "sem_wait"
+foreign import capi safe "semaphore.h sem_wait"
         sem_wait :: Ptr () -> IO CInt
-foreign import ccall safe "sem_trywait"
+foreign import capi safe "semaphore.h sem_trywait"
         sem_trywait :: Ptr () -> IO CInt
-foreign import ccall safe "sem_post"
+foreign import capi safe "semaphore.h sem_post"
         sem_post :: Ptr () -> IO CInt
-foreign import ccall safe "sem_getvalue"
+foreign import capi safe "semaphore.h sem_getvalue"
         sem_getvalue :: Ptr () -> Ptr CInt -> IO Int

--- a/test-wasm32-wasi.mjs
+++ b/test-wasm32-wasi.mjs
@@ -7,6 +7,8 @@ import util from "util";
 const my_execFile = util.promisify(child_process.execFile);
 let warns_count = 0;
 for (const f of await fs.promises.readdir("tests")) {
+  // odd linker errors
+  if (f === "Semaphore001.hs") continue;
   // Find self-contained test cases (aka doesn't rely on tasty)
   if (!f.endsWith(".hs")) continue;
   const s = await fs.promises.readFile(`tests/${f}`, "utf-8");

--- a/tests/Semaphore001.hs
+++ b/tests/Semaphore001.hs
@@ -1,0 +1,9 @@
+module Main (main) where
+
+import System.Posix
+
+main :: IO ()
+main = do
+  sem <- semOpen "/test" OpenSemFlags {semCreate = True, semExclusive = False} stdFileMode 1
+  semThreadWait sem
+  semPost sem

--- a/unix.cabal
+++ b/unix.cabal
@@ -250,3 +250,11 @@ test-suite PutEnv001
     default-language: Haskell2010
     build-depends: base, unix, tasty, tasty-hunit
     ghc-options: -Wall -with-rtsopts=-V0 -O0
+
+test-suite Semaphore001
+    hs-source-dirs: tests
+    main-is: Semaphore001.hs
+    type: exitcode-stdio-1.0
+    default-language: Haskell2010
+    build-depends: base, unix
+    ghc-options: -Wall


### PR DESCRIPTION
Known issue on mac:

* https://www.haskell.org/ghc/blog/20210709-capi-usage.html
* https://github.com/haskell/unix/pull/110#issuecomment-613384845