### PR TITLE
Avoid redundant pattern warning in Resource.hsc (#238)

### DIFF
--- a/System/Posix/Resource.hsc
+++ b/System/Posix/Resource.hsc
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
-{-# LANGUAGE Safe #-}
+{-# LANGUAGE Trustworthy #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.Posix.Resource
@@ -30,6 +31,9 @@ import Foreign.C
 #if !defined(HAVE_STRUCT_RLIMIT)
 import System.IO.Error ( ioeSetLocation )
 import GHC.IO.Exception ( unsupportedOperation )
+#endif
+#if __GLASGOW_HASKELL__ >= 905
+import GHC.Exts ( considerAccessible )
 #endif
 
 -- -----------------------------------------------------------------------------
@@ -115,12 +119,20 @@ unpackRLimit :: CRLim -> ResourceLimit
 unpackRLimit (#const RLIM_INFINITY)  = ResourceLimitInfinity
 unpackRLimit other
 #if defined(RLIM_SAVED_MAX)
-    | ((#const RLIM_SAVED_MAX) :: CRLim) /= (#const RLIM_INFINITY) &&
-      other == (#const RLIM_SAVED_MAX) = ResourceLimitUnknown
+    | ((#const RLIM_SAVED_MAX) :: CRLim) /= (#const RLIM_INFINITY)
+    , other == (#const RLIM_SAVED_MAX)
+    = ResourceLimitUnknown
 #endif
 #if defined(RLIM_SAVED_CUR)
-    | ((#const RLIM_SAVED_CUR) :: CRLim) /= (#const RLIM_INFINITY) &&
-      other == (#const RLIM_SAVED_CUR) = ResourceLimitUnknown
+    | ((#const RLIM_SAVED_CUR) :: CRLim) /= (#const RLIM_INFINITY)
+    , other == (#const RLIM_SAVED_CUR)
+#if __GLASGOW_HASKELL__ >= 905
+    , considerAccessible
+#endif
+    = ResourceLimitUnknown
+    -- (*) This pattern match is redundant if RLIM_SAVED_MAX and RLIM_SAVED_CUR
+    -- are both defined and are equal. This redundancy is only detected by GHC
+    -- starting from version 9.5, so we use 'considerAccessible'.
 #endif
     | otherwise = ResourceLimit (fromIntegral other)
 


### PR DESCRIPTION
This is a cherry-pick of #238 to the master branch.