### PR TITLE
Final touches for 2.8

### DIFF
--- a/System/Posix/Resource.hsc
+++ b/System/Posix/Resource.hsc
@@ -1,5 +1,9 @@
 {-# LANGUAGE CApiFFI #-}
+#if __GLASGOW_HASKELL__ >= 905
 {-# LANGUAGE Trustworthy #-}
+#else
+{-# LANGUAGE Safe #-}
+#endif
 
 -----------------------------------------------------------------------------
 -- |

--- a/unix.cabal
+++ b/unix.cabal
@@ -11,8 +11,9 @@ bug-reports:    https://github.com/haskell/unix/issues
 synopsis:       POSIX functionality
 category:       System
 build-type:     Configure
-tested-with:    GHC==9.0.1,
-                GHC==8.10.4,
+tested-with:    GHC==9.2.4,
+                GHC==9.0.2,
+                GHC==8.10.7,
                 GHC==8.8.4,
                 GHC==8.6.5,
                 GHC==8.4.4,
@@ -68,9 +69,9 @@ library
         buildable: False
 
     build-depends:
-        base        >= 4.10    && < 4.17,
+        base        >= 4.10    && < 4.18,
         bytestring  >= 0.9.2   && < 0.12,
-        filepath    >= 1.4.100.0,
+        filepath    >= 1.4.100.0 && < 1.5,
         time        >= 1.2     && < 1.13
 
     exposed-modules:


### PR DESCRIPTION
Unfortunately #238 introduced a warning message, which is not an option for a boot library. I also bumped upper bound for `base` (tested with GHC 9.4 RC1), otherwise we won't be able to update GHC submodule.