### PR TITLE
Fix FreeBSD CI job

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-13-0
+  image_family: freebsd-13-1
 
 task:
   install_script: pkg install -y ghc hs-cabal-install git autoconf


### PR DESCRIPTION
Not sure why Cirrus CI stopped working with FreeBSD 13.0, but whatever.