### PR TITLE
Fix WASI build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-13-0
+  image_family: freebsd-13-1
 
 task:
   install_script: pkg install -y ghc hs-cabal-install git autoconf


### PR DESCRIPTION
The `System.Posix.Files.PosixString` and `System.Posix.Temp.PosixString` modules failed to build on the WASI/WASM platform because foreign imports of `mkstemp` and `mknod` was not conditional on `configure` findings.

This patch aligns these modules with their non-`PosixString` counterparts.

See: https://github.com/haskell/unix/pull/245
See: https://github.com/haskell/unix/pull/246
See: https://github.com/haskell/unix/runs/8284652815?check_suite_focus=true