### PR TITLE
ci: update Fedora tests to Fedora 36

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,10 @@ jobs:
         autoreconf -i
         cabal test all --test-show-details=direct
 
-  fedora34:
+  fedora36:
     runs-on: ubuntu-latest
     container:
-      image: fedora:34
+      image: fedora:36
     steps:
     - name: Install
       run: |


### PR DESCRIPTION
Fedora 34 has been EOL since 2022-06-07.

See: https://docs.fedoraproject.org/en-US/releases/eol/