### PR TITLE
Expose dirent pointer and added readDirStreamWith

### DIFF
--- a/System/Posix/Directory.hsc
+++ b/System/Posix/Directory.hsc
@@ -30,30 +30,14 @@ module System.Posix.Directory (
    -- * Reading directories
    DirStream,
    DirType( DtUnknown
-#ifdef CONST_DT_FIFO
           , DtFifo
-#endif
-#ifdef CONST_DT_CHR
           , DtChr
-#endif
-#ifdef CONST_DT_DIR
           , DtDir
-#endif
-#ifdef CONST_DT_BLK
           , DtBlk
-#endif
-#ifdef CONST_DT_REG
           , DtReg
-#endif
-#ifdef CONST_DT_LNK
           , DtLnk
-#endif
-#ifdef CONST_DT_SOCK
           , DtSock
-#endif
-#ifdef CONST_DT_WHT
           , DtWht
-#endif
           ),
    openDirStream,
    readDirStream,

--- a/System/Posix/Directory.hsc
+++ b/System/Posix/Directory.hsc
@@ -29,16 +29,19 @@ module System.Posix.Directory (
 
    -- * Reading directories
    DirStream,
-   DirType( DtUnknown
-          , DtFifo
-          , DtChr
-          , DtDir
-          , DtBlk
-          , DtReg
-          , DtLnk
-          , DtSock
-          , DtWht
+   DirType( UnknownType
+          , NamedPipeType
+          , CharacterDeviceType
+          , DirectoryType
+          , BlockDeviceType
+          , RegularFileType
+          , SymbolicLinkType
+          , SocketType
+          , WhiteoutType
           ),
+   isUnknownType, isBlockDeviceType, isCharacterDeviceType, isNamedPipeType,
+   isRegularFileType, isDirectoryType, isSymbolicLinkType, isSocketType,
+   isWhiteoutType,
    openDirStream,
    readDirStream,
    readDirStreamMaybe,
@@ -118,6 +121,9 @@ readDirStreamMaybe = readDirStreamWith
 --   structure together with the entry's type (@d_type@) wrapped in a
 --   @Just (d_name, d_type)@ if an entry was read and @Nothing@ if
 --   the end of the directory stream was reached.
+--
+--   __Note__: The returned 'DirType' has some limitations; Please see its
+--   documentation.
 readDirStreamWithType :: DirStream -> IO (Maybe (FilePath, DirType))
 readDirStreamWithType = readDirStreamWith
   (\(DirEnt dEnt) -> (,)

--- a/System/Posix/Directory/ByteString.hsc
+++ b/System/Posix/Directory/ByteString.hsc
@@ -1,5 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE NondecreasingIndentation #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Safe #-}
 
 -----------------------------------------------------------------------------
@@ -28,7 +29,8 @@ module System.Posix.Directory.ByteString (
    createDirectory, removeDirectory,
 
    -- * Reading directories
-   DirStream,
+   DirStream, DirStreamWithPath,
+   fromDirStreamWithPath,
    DirType( UnknownType
           , NamedPipeType
           , CharacterDeviceType
@@ -43,6 +45,7 @@ module System.Posix.Directory.ByteString (
    isRegularFileType, isDirectoryType, isSymbolicLinkType, isSocketType,
    isWhiteoutType,
    openDirStream,
+   openDirStreamWithPath,
    readDirStream,
    readDirStreamMaybe,
    readDirStreamWithType,
@@ -70,6 +73,7 @@ import Foreign.C
 import Data.ByteString.Char8 as BC
 
 import System.Posix.Directory.Common
+import System.Posix.Files.ByteString
 import System.Posix.ByteString.FilePath
 
 -- | @createDirectory dir mode@ calls @mkdir@ to
@@ -92,6 +96,11 @@ openDirStream name =
   withFilePath name $ \s -> do
     dirp <- throwErrnoPathIfNullRetry "openDirStream" name $ c_opendir s
     return (DirStream dirp)
+
+-- | A version of 'openDirStream' where the path of the directory is stored in
+-- the returned 'DirStreamWithPath'.
+openDirStreamWithPath :: RawFilePath -> IO (DirStreamWithPath RawFilePath)
+openDirStreamWithPath name = toDirStreamWithPath name <$> openDirStream name
 
 foreign import capi unsafe "HsUnix.h opendir"
    c_opendir :: CString  -> IO (Ptr CDir)
@@ -125,12 +134,15 @@ readDirStreamMaybe = readDirStreamWith
 --
 --   __Note__: The returned 'DirType' has some limitations; Please see its
 --   documentation.
-readDirStreamWithType :: DirStream -> IO (Maybe (RawFilePath, DirType))
-readDirStreamWithType = readDirStreamWith
-  (\(DirEnt dEnt) -> (,)
-    <$> (d_name dEnt >>= peekFilePath)
-    <*> (DirType <$> d_type dEnt)
+readDirStreamWithType :: DirStreamWithPath RawFilePath -> IO (Maybe (RawFilePath, DirType))
+readDirStreamWithType (DirStreamWithPath (base, ptr)) = readDirStreamWith
+  (\(DirEnt dEnt) -> do
+    name <- d_name dEnt >>= peekFilePath
+    let getStat = getFileStatus (base <> "/" <> name)
+    dtype <- d_type dEnt >>= getRealDirType getStat . DirType
+    return (name, dtype)
   )
+  (DirStream ptr)
 
 foreign import ccall unsafe "__hscore_d_name"
   d_name :: Ptr CDirent -> IO CString

--- a/System/Posix/Directory/ByteString.hsc
+++ b/System/Posix/Directory/ByteString.hsc
@@ -71,6 +71,9 @@ import Foreign
 import Foreign.C
 
 import Data.ByteString.Char8 as BC
+#if !MIN_VERSION_base(4,11,0)
+import Data.Monoid ((<>))
+#endif
 
 import System.Posix.Directory.Common
 import System.Posix.Files.ByteString

--- a/System/Posix/Directory/ByteString.hsc
+++ b/System/Posix/Directory/ByteString.hsc
@@ -29,16 +29,19 @@ module System.Posix.Directory.ByteString (
 
    -- * Reading directories
    DirStream,
-   DirType( DtUnknown
-          , DtFifo
-          , DtChr
-          , DtDir
-          , DtBlk
-          , DtReg
-          , DtLnk
-          , DtSock
-          , DtWht
+   DirType( UnknownType
+          , NamedPipeType
+          , CharacterDeviceType
+          , DirectoryType
+          , BlockDeviceType
+          , RegularFileType
+          , SymbolicLinkType
+          , SocketType
+          , WhiteoutType
           ),
+   isUnknownType, isBlockDeviceType, isCharacterDeviceType, isNamedPipeType,
+   isRegularFileType, isDirectoryType, isSymbolicLinkType, isSocketType,
+   isWhiteoutType,
    openDirStream,
    readDirStream,
    readDirStreamMaybe,
@@ -119,6 +122,9 @@ readDirStreamMaybe = readDirStreamWith
 --   structure together with the entry's type (@d_type@) wrapped in a
 --   @Just (d_name, d_type)@ if an entry was read and @Nothing@ if
 --   the end of the directory stream was reached.
+--
+--   __Note__: The returned 'DirType' has some limitations; Please see its
+--   documentation.
 readDirStreamWithType :: DirStream -> IO (Maybe (RawFilePath, DirType))
 readDirStreamWithType = readDirStreamWith
   (\(DirEnt dEnt) -> (,)

--- a/System/Posix/Directory/ByteString.hsc
+++ b/System/Posix/Directory/ByteString.hsc
@@ -30,30 +30,14 @@ module System.Posix.Directory.ByteString (
    -- * Reading directories
    DirStream,
    DirType( DtUnknown
-#ifdef CONST_DT_FIFO
           , DtFifo
-#endif
-#ifdef CONST_DT_CHR
           , DtChr
-#endif
-#ifdef CONST_DT_DIR
           , DtDir
-#endif
-#ifdef CONST_DT_BLK
           , DtBlk
-#endif
-#ifdef CONST_DT_REG
           , DtReg
-#endif
-#ifdef CONST_DT_LNK
           , DtLnk
-#endif
-#ifdef CONST_DT_SOCK
           , DtSock
-#endif
-#ifdef CONST_DT_WHT
           , DtWht
-#endif
           ),
    openDirStream,
    readDirStream,

--- a/System/Posix/Directory/ByteString.hsc
+++ b/System/Posix/Directory/ByteString.hsc
@@ -1,6 +1,5 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Safe #-}
 
 -----------------------------------------------------------------------------
@@ -29,26 +28,10 @@ module System.Posix.Directory.ByteString (
    createDirectory, removeDirectory,
 
    -- * Reading directories
-   DirStream, DirStreamWithPath,
-   fromDirStreamWithPath,
-   DirType( UnknownType
-          , NamedPipeType
-          , CharacterDeviceType
-          , DirectoryType
-          , BlockDeviceType
-          , RegularFileType
-          , SymbolicLinkType
-          , SocketType
-          , WhiteoutType
-          ),
-   isUnknownType, isBlockDeviceType, isCharacterDeviceType, isNamedPipeType,
-   isRegularFileType, isDirectoryType, isSymbolicLinkType, isSocketType,
-   isWhiteoutType,
+   DirStream,
    openDirStream,
-   openDirStreamWithPath,
    readDirStream,
    readDirStreamMaybe,
-   readDirStreamWithType,
    rewindDirStream,
    closeDirStream,
    DirStreamOffset,
@@ -65,18 +48,15 @@ module System.Posix.Directory.ByteString (
    changeWorkingDirectoryFd,
   ) where
 
+import Control.Monad ((>=>))
 import Data.Maybe
 import System.Posix.Types
 import Foreign
 import Foreign.C
 
 import Data.ByteString.Char8 as BC
-#if !MIN_VERSION_base(4,11,0)
-import Data.Monoid ((<>))
-#endif
 
 import System.Posix.Directory.Common
-import System.Posix.Files.ByteString
 import System.Posix.ByteString.FilePath
 
 -- | @createDirectory dir mode@ calls @mkdir@ to
@@ -100,11 +80,6 @@ openDirStream name =
     dirp <- throwErrnoPathIfNullRetry "openDirStream" name $ c_opendir s
     return (DirStream dirp)
 
--- | A version of 'openDirStream' where the path of the directory is stored in
--- the returned 'DirStreamWithPath'.
-openDirStreamWithPath :: RawFilePath -> IO (DirStreamWithPath RawFilePath)
-openDirStreamWithPath name = toDirStreamWithPath name <$> openDirStream name
-
 foreign import capi unsafe "HsUnix.h opendir"
    c_opendir :: CString  -> IO (Ptr CDir)
 
@@ -125,33 +100,7 @@ readDirStream = fmap (fromMaybe BC.empty) . readDirStreamMaybe
 --   structure wrapped in a @Just d_name@ if an entry was read and @Nothing@ if
 --   the end of the directory stream was reached.
 readDirStreamMaybe :: DirStream -> IO (Maybe RawFilePath)
-readDirStreamMaybe = readDirStreamWith
-  (\(DirEnt dEnt) -> d_name dEnt >>= peekFilePath)
-
--- | @readDirStreamWithType dp@ calls @readdir@ to obtain the
---   next directory entry (@struct dirent@) for the open directory
---   stream @dp@. It returns the @d_name@ member of that
---   structure together with the entry's type (@d_type@) wrapped in a
---   @Just (d_name, d_type)@ if an entry was read and @Nothing@ if
---   the end of the directory stream was reached.
---
---   __Note__: The returned 'DirType' has some limitations; Please see its
---   documentation.
-readDirStreamWithType :: DirStreamWithPath RawFilePath -> IO (Maybe (RawFilePath, DirType))
-readDirStreamWithType (DirStreamWithPath (base, ptr)) = readDirStreamWith
-  (\(DirEnt dEnt) -> do
-    name <- d_name dEnt >>= peekFilePath
-    let getStat = getFileStatus (base <> "/" <> name)
-    dtype <- d_type dEnt >>= getRealDirType getStat . DirType
-    return (name, dtype)
-  )
-  (DirStream ptr)
-
-foreign import ccall unsafe "__hscore_d_name"
-  d_name :: Ptr CDirent -> IO CString
-
-foreign import ccall unsafe "__hscore_d_type"
-  d_type :: Ptr CDirent -> IO CChar
+readDirStreamMaybe = readDirStreamWith (dirEntName >=> peekFilePath)
 
 
 -- | @getWorkingDirectory@ calls @getcwd@ to obtain the name

--- a/System/Posix/Directory/Common.hsc
+++ b/System/Posix/Directory/Common.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE Safe, CApiFFI #-}
+{-# LANGUAGE CPP, Safe, CApiFFI, PatternSynonyms #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -15,10 +15,41 @@
 -----------------------------------------------------------------------------
 
 #include "HsUnix.h"
+#include "HsUnixConfig.h"
+##include "HsUnixConfig.h"
 
 module System.Posix.Directory.Common (
        DirStream(..), DirEnt(..), CDir, CDirent, DirStreamOffset(..),
+       DirType( DirType
+              , DtUnknown
+#ifdef CONST_DT_FIFO
+              , DtFifo
+#endif
+#ifdef CONST_DT_CHR
+              , DtChr
+#endif
+#ifdef CONST_DT_DIR
+              , DtDir
+#endif
+#ifdef CONST_DT_BLK
+              , DtBlk
+#endif
+#ifdef CONST_DT_REG
+              , DtReg
+#endif
+#ifdef CONST_DT_LNK
+              , DtLnk
+#endif
+#ifdef CONST_DT_SOCK
+              , DtSock
+#endif
+#ifdef CONST_DT_WHT
+              , DtWht
+#endif
+              ),
        unsafeOpenDirStreamFd,
+       readDirStreamWith,
+       readDirStreamWithPtr,
        rewindDirStream,
        closeDirStream,
 #ifdef HAVE_SEEKDIR
@@ -63,6 +94,55 @@ instance Storable DirEnt where
 data {-# CTYPE "DIR" #-} CDir
 data {-# CTYPE "struct dirent" #-} CDirent
 
+newtype DirType = DirType CChar
+
+pattern DtUnknown :: DirType
+#ifdef CONST_DT_UNKNOWN
+pattern DtUnknown = DirType CONST_DT_UNKNOWN
+#else
+pattern DtUnknown = DirType 0
+#endif
+
+#ifdef CONST_DT_FIFO
+pattern DtFifo :: DirType
+pattern DtFifo = DirType CONST_DT_FIFO
+#endif
+
+#ifdef CONST_DT_CHR
+pattern DtChr :: DirType
+pattern DtChr = DirType CONST_DT_CHR
+#endif
+
+#ifdef CONST_DT_DIR
+pattern DtDir :: DirType
+pattern DtDir = DirType CONST_DT_DIR
+#endif
+
+#ifdef CONST_DT_BLK
+pattern DtBlk :: DirType
+pattern DtBlk = DirType CONST_DT_BLK
+#endif
+
+#ifdef CONST_DT_REG
+pattern DtReg :: DirType
+pattern DtReg = DirType CONST_DT_REG
+#endif
+
+#ifdef CONST_DT_LNK
+pattern DtLnk :: DirType
+pattern DtLnk = DirType CONST_DT_LNK
+#endif
+
+#ifdef CONST_DT_SOCK
+pattern DtSock :: DirType
+pattern DtSock = DirType CONST_DT_SOCK
+#endif
+
+#ifdef CONST_DT_WHT
+pattern DtWht :: DirType
+pattern DtWht = DirType CONST_DT_WHT
+#endif
+
 -- | Call @fdopendir@ to obtain a directory stream for @fd@. @fd@ must not be
 -- otherwise used after this.
 --
@@ -94,6 +174,63 @@ foreign import ccall unsafe "HsUnix.h close"
 --
 foreign import capi unsafe "dirent.h fdopendir"
     c_fdopendir :: CInt -> IO (Ptr CDir)
+
+-- | @readDirStreamWith f dp@ calls @readdir@ to obtain the next directory entry
+--   (@struct dirent@) for the open directory stream @dp@. If an entry is read,
+--   it passes the pointer to that structure to the provided function @f@ for
+--   processing. It returns the result of that function call wrapped in a @Just@
+--   if an entry was read and @Nothing@ if the end of the directory stream was
+--   reached.
+--
+--   __NOTE:__ The lifetime of the pointer wrapped in the `DirEnt` is limited to
+--   invocation of the callback and it will be freed automatically after. Do not
+--   pass it to the outside world!
+readDirStreamWith :: (DirEnt -> IO a) -> DirStream -> IO (Maybe a)
+readDirStreamWith f dstream = alloca
+  (\ptr_dEnt  -> readDirStreamWithPtr ptr_dEnt f dstream)
+
+-- | A version of 'readDirStreamWith' that takes a pre-allocated pointer in
+--   addition to the other arguments. This pointer is used to store the pointer
+--   to the next directory entry, if there is any. This function is intended for
+--   usecases where you need to read a lot of directory entries and want to
+--   reuse the pointer for each of them. Using for example 'readDirStream' or
+--   'readDirStreamWith' in this scenario would allocate a new pointer for each
+--   call of these functions.
+--
+--   __NOTE__: You are responsible for releasing the pointer after you are done.
+readDirStreamWithPtr :: Ptr DirEnt -> (DirEnt -> IO a) -> DirStream -> IO (Maybe a)
+readDirStreamWithPtr ptr_dEnt f dstream@(DirStream dirp) = do
+  resetErrno
+  r <- c_readdir dirp (castPtr ptr_dEnt)
+  if (r == 0)
+       then do dEnt@(DirEnt dEntPtr) <- peek ptr_dEnt
+               if (dEntPtr == nullPtr)
+                  then return Nothing
+                  else do
+                   res <- f dEnt
+                   c_freeDirEnt dEntPtr
+                   return (Just res)
+       else do errno <- getErrno
+               if (errno == eINTR)
+                  then readDirStreamWithPtr ptr_dEnt f dstream
+                  else do
+                   let (Errno eo) = errno
+                   if (eo == 0)
+                      then return Nothing
+                      else throwErrno "readDirStream"
+
+-- traversing directories
+foreign import ccall unsafe "__hscore_readdir"
+  c_readdir  :: Ptr CDir -> Ptr (Ptr CDirent) -> IO CInt
+
+foreign import ccall unsafe "__hscore_free_dirent"
+  c_freeDirEnt  :: Ptr CDirent -> IO ()
+
+foreign import ccall unsafe "__hscore_d_name"
+  d_name :: Ptr CDirent -> IO CString
+
+foreign import ccall unsafe "__hscore_d_type"
+  d_type :: Ptr CDirent -> IO CChar
 
 -- | @rewindDirStream dp@ calls @rewinddir@ to reposition
 --   the directory stream @dp@ at the beginning of the directory.

--- a/System/Posix/Directory/Common.hsc
+++ b/System/Posix/Directory/Common.hsc
@@ -17,7 +17,7 @@
 #include "HsUnix.h"
 
 module System.Posix.Directory.Common (
-       DirStream(..), CDir, CDirent, DirStreamOffset(..),
+       DirStream(..), DirEnt(..), CDir, CDirent, DirStreamOffset(..),
        unsafeOpenDirStreamFd,
        rewindDirStream,
        closeDirStream,
@@ -42,6 +42,8 @@ import GHC.IO.Exception ( unsupportedOperation )
 #endif
 
 newtype DirStream = DirStream (Ptr CDir)
+
+newtype DirEnt = DirEnt (Ptr CDirent)
 
 data {-# CTYPE "DIR" #-} CDir
 data {-# CTYPE "struct dirent" #-} CDirent

--- a/System/Posix/Directory/Common.hsc
+++ b/System/Posix/Directory/Common.hsc
@@ -22,30 +22,14 @@ module System.Posix.Directory.Common (
        DirStream(..), DirEnt(..), CDir, CDirent, DirStreamOffset(..),
        DirType( DirType
               , DtUnknown
-#ifdef CONST_DT_FIFO
               , DtFifo
-#endif
-#ifdef CONST_DT_CHR
               , DtChr
-#endif
-#ifdef CONST_DT_DIR
               , DtDir
-#endif
-#ifdef CONST_DT_BLK
               , DtBlk
-#endif
-#ifdef CONST_DT_REG
               , DtReg
-#endif
-#ifdef CONST_DT_LNK
               , DtLnk
-#endif
-#ifdef CONST_DT_SOCK
               , DtSock
-#endif
-#ifdef CONST_DT_WHT
               , DtWht
-#endif
               ),
        unsafeOpenDirStreamFd,
        readDirStreamWith,
@@ -97,51 +81,31 @@ data {-# CTYPE "struct dirent" #-} CDirent
 newtype DirType = DirType CChar
 
 pattern DtUnknown :: DirType
-#ifdef CONST_DT_UNKNOWN
 pattern DtUnknown = DirType CONST_DT_UNKNOWN
-#else
-pattern DtUnknown = DirType 0
-#endif
 
-#ifdef CONST_DT_FIFO
 pattern DtFifo :: DirType
-pattern DtFifo = DirType CONST_DT_FIFO
-#endif
+pattern DtFifo = DirType (CONST_DT_FIFO)
 
-#ifdef CONST_DT_CHR
 pattern DtChr :: DirType
-pattern DtChr = DirType CONST_DT_CHR
-#endif
+pattern DtChr = DirType (CONST_DT_CHR)
 
-#ifdef CONST_DT_DIR
 pattern DtDir :: DirType
-pattern DtDir = DirType CONST_DT_DIR
-#endif
+pattern DtDir = DirType (CONST_DT_DIR)
 
-#ifdef CONST_DT_BLK
 pattern DtBlk :: DirType
-pattern DtBlk = DirType CONST_DT_BLK
-#endif
+pattern DtBlk = DirType (CONST_DT_BLK)
 
-#ifdef CONST_DT_REG
 pattern DtReg :: DirType
-pattern DtReg = DirType CONST_DT_REG
-#endif
+pattern DtReg = DirType (CONST_DT_REG)
 
-#ifdef CONST_DT_LNK
 pattern DtLnk :: DirType
-pattern DtLnk = DirType CONST_DT_LNK
-#endif
+pattern DtLnk = DirType (CONST_DT_LNK)
 
-#ifdef CONST_DT_SOCK
 pattern DtSock :: DirType
-pattern DtSock = DirType CONST_DT_SOCK
-#endif
+pattern DtSock = DirType (CONST_DT_SOCK)
 
-#ifdef CONST_DT_WHT
 pattern DtWht :: DirType
-pattern DtWht = DirType CONST_DT_WHT
-#endif
+pattern DtWht = DirType (CONST_DT_WHT)
 
 -- | Call @fdopendir@ to obtain a directory stream for @fd@. @fd@ must not be
 -- otherwise used after this.

--- a/System/Posix/Directory/Common.hsc
+++ b/System/Posix/Directory/Common.hsc
@@ -45,6 +45,21 @@ newtype DirStream = DirStream (Ptr CDir)
 
 newtype DirEnt = DirEnt (Ptr CDirent)
 
+-- We provide a hand-written instance here since GeneralizedNewtypeDeriving and
+-- DerivingVia are not allowed in Safe Haskell.
+instance Storable DirEnt where
+  sizeOf _ = sizeOf (undefined :: Ptr CDirent)
+  {-# INLINE sizeOf #-}
+
+  alignment _ = alignment (undefined :: Ptr CDirent)
+  {-# INLINE alignment #-}
+
+  peek ptr = DirEnt <$> peek (castPtr ptr)
+  {-# INLINE peek #-}
+
+  poke ptr (DirEnt dEnt) = poke (castPtr ptr) dEnt
+  {-# INLINE poke#-}
+
 data {-# CTYPE "DIR" #-} CDir
 data {-# CTYPE "struct dirent" #-} CDirent
 

--- a/System/Posix/Directory/Common.hsc
+++ b/System/Posix/Directory/Common.hsc
@@ -196,12 +196,12 @@ getRealDirType _ SocketType = return SocketType
 getRealDirType _ WhiteoutType = return WhiteoutType
 getRealDirType getFileStatus _ = do
     stat <- getFileStatus
-    return $ if | isBlockDevice stat -> BlockDeviceType
-                | isCharacterDevice stat -> CharacterDeviceType
-                | isNamedPipe stat -> NamedPipeType
-                | isRegularFile stat -> RegularFileType
+    return $ if | isRegularFile stat -> RegularFileType
                 | isDirectory stat -> DirectoryType
                 | isSymbolicLink stat -> SymbolicLinkType
+                | isBlockDevice stat -> BlockDeviceType
+                | isCharacterDevice stat -> CharacterDeviceType
+                | isNamedPipe stat -> NamedPipeType
                 | isSocket stat -> SocketType
                 | otherwise -> UnknownType
 
@@ -255,7 +255,7 @@ readDirStreamWith f dstream = alloca
 -- | A version of 'readDirStreamWith' that takes a pre-allocated pointer in
 --   addition to the other arguments. This pointer is used to store the pointer
 --   to the next directory entry, if there is any. This function is intended for
---   usecases where you need to read a lot of directory entries and want to
+--   use cases where you need to read a lot of directory entries and want to
 --   reuse the pointer for each of them. Using for example 'readDirStream' or
 --   'readDirStreamWith' in this scenario would allocate a new pointer for each
 --   call of these functions.

--- a/System/Posix/Directory/Common.hsc
+++ b/System/Posix/Directory/Common.hsc
@@ -175,6 +175,7 @@ foreign import ccall unsafe "HsUnix.h close"
 foreign import capi unsafe "dirent.h fdopendir"
     c_fdopendir :: CInt -> IO (Ptr CDir)
 
+
 -- | @readDirStreamWith f dp@ calls @readdir@ to obtain the next directory entry
 --   (@struct dirent@) for the open directory stream @dp@. If an entry is read,
 --   it passes the pointer to that structure to the provided function @f@ for
@@ -226,11 +227,6 @@ foreign import ccall unsafe "__hscore_readdir"
 foreign import ccall unsafe "__hscore_free_dirent"
   c_freeDirEnt  :: Ptr CDirent -> IO ()
 
-foreign import ccall unsafe "__hscore_d_name"
-  d_name :: Ptr CDirent -> IO CString
-
-foreign import ccall unsafe "__hscore_d_type"
-  d_type :: Ptr CDirent -> IO CChar
 
 -- | @rewindDirStream dp@ calls @rewinddir@ to reposition
 --   the directory stream @dp@ at the beginning of the directory.

--- a/System/Posix/Directory/Common.hsc
+++ b/System/Posix/Directory/Common.hsc
@@ -101,39 +101,39 @@ newtype DirType = DirType CChar
 
 -- | The 'DirType' refers to an entry of unknown type.
 pattern UnknownType :: DirType
-pattern UnknownType = DirType CONST_DT_UNKNOWN
+pattern UnknownType = DirType (CONST_DT_UNKNOWN)
 
 -- | The 'DirType' refers to an entry that is a named pipe.
 pattern NamedPipeType :: DirType
-pattern NamedPipeType = DirType CONST_DT_FIFO
+pattern NamedPipeType = DirType (CONST_DT_FIFO)
 
 -- | The 'DirType' refers to an entry that is a character device.
 pattern CharacterDeviceType :: DirType
-pattern CharacterDeviceType = DirType CONST_DT_CHR
+pattern CharacterDeviceType = DirType (CONST_DT_CHR)
 
 -- | The 'DirType' refers to an entry that is a directory.
 pattern DirectoryType :: DirType
-pattern DirectoryType = DirType CONST_DT_DIR
+pattern DirectoryType = DirType (CONST_DT_DIR)
 
 -- | The 'DirType' refers to an entry that is a block device.
 pattern BlockDeviceType :: DirType
-pattern BlockDeviceType = DirType CONST_DT_BLK
+pattern BlockDeviceType = DirType (CONST_DT_BLK)
 
 -- | The 'DirType' refers to an entry that is a regular file.
 pattern RegularFileType :: DirType
-pattern RegularFileType = DirType CONST_DT_REG
+pattern RegularFileType = DirType (CONST_DT_REG)
 
 -- | The 'DirType' refers to an entry that is a symbolic link.
 pattern SymbolicLinkType :: DirType
-pattern SymbolicLinkType = DirType CONST_DT_LNK
+pattern SymbolicLinkType = DirType (CONST_DT_LNK)
 
 -- | The 'DirType' refers to an entry that is a socket.
 pattern SocketType :: DirType
-pattern SocketType = DirType CONST_DT_SOCK
+pattern SocketType = DirType (CONST_DT_SOCK)
 
 -- | The 'DirType' refers to an entry that is a whiteout.
 pattern WhiteoutType :: DirType
-pattern WhiteoutType = DirType CONST_DT_WHT
+pattern WhiteoutType = DirType (CONST_DT_WHT)
 
 -- | Checks if this 'DirType' refers to an entry of unknown type.
 isUnknownType         :: DirType -> Bool

--- a/System/Posix/Directory/Common.hsc
+++ b/System/Posix/Directory/Common.hsc
@@ -19,9 +19,16 @@
 ##include "HsUnixConfig.h"
 
 module System.Posix.Directory.Common (
-       DirStream(..), DirStreamWithPath(..),
-       fromDirStreamWithPath, toDirStreamWithPath,
-       DirEnt(..), CDir, CDirent, DirStreamOffset(..),
+       DirStream(..),
+       CDir,
+       DirStreamWithPath(..),
+       fromDirStreamWithPath,
+       toDirStreamWithPath,
+
+       DirEnt(..),
+       CDirent,
+       dirEntName,
+       dirEntType,
        DirType( DirType
               , UnknownType
               , NamedPipeType
@@ -40,6 +47,8 @@ module System.Posix.Directory.Common (
        unsafeOpenDirStreamFd,
        readDirStreamWith,
        readDirStreamWithPtr,
+
+       DirStreamOffset(..),
        rewindDirStream,
        closeDirStream,
 #ifdef HAVE_SEEKDIR
@@ -281,6 +290,18 @@ readDirStreamWithPtr ptr_dEnt f dstream@(DirStream dirp) = do
                    if (eo == 0)
                       then return Nothing
                       else throwErrno "readDirStream"
+
+dirEntName :: DirEnt -> IO CString
+dirEntName (DirEnt dEntPtr) = d_name dEntPtr
+
+foreign import ccall unsafe "__hscore_d_name"
+  d_name :: Ptr CDirent -> IO CString
+
+dirEntType :: DirEnt -> IO DirType
+dirEntType (DirEnt dEntPtr) = DirType <$> d_type dEntPtr
+
+foreign import ccall unsafe "__hscore_d_type"
+  d_type :: Ptr CDirent -> IO CChar
 
 -- traversing directories
 foreign import ccall unsafe "__hscore_readdir"

--- a/System/Posix/Directory/Internals.hsc
+++ b/System/Posix/Directory/Internals.hsc
@@ -12,6 +12,10 @@
 --
 -----------------------------------------------------------------------------
 
-module System.Posix.Directory.Internals ( DirStream(..), CDir, CDirent, DirStreamOffset(..) ) where
+module System.Posix.Directory.Internals (
+    DirStream(..), DirEnt(..), DirType(..), CDir, CDirent, DirStreamOffset(..),
+    readDirStreamWith, 
+    readDirStreamWithPtr, 
+    ) where
 
 import System.Posix.Directory.Common

--- a/System/Posix/Directory/Internals.hsc
+++ b/System/Posix/Directory/Internals.hsc
@@ -13,9 +13,39 @@
 -----------------------------------------------------------------------------
 
 module System.Posix.Directory.Internals (
-    DirStream(..), DirEnt(..), DirType(..), CDir, CDirent, DirStreamOffset(..),
-    readDirStreamWith, 
-    readDirStreamWithPtr, 
+    DirStream(..),
+    CDir,
+    DirStreamWithPath(..),
+    fromDirStreamWithPath,
+    toDirStreamWithPath,
+    DirEnt(..),
+    CDirent,
+    dirEntName,
+    dirEntType,
+    DirType( DirType
+           , UnknownType
+           , NamedPipeType
+           , CharacterDeviceType
+           , DirectoryType
+           , BlockDeviceType
+           , RegularFileType
+           , SymbolicLinkType
+           , SocketType
+           , WhiteoutType
+           ),
+    isUnknownType,
+    isNamedPipeType,
+    isCharacterDeviceType,
+    isDirectoryType,
+    isBlockDeviceType,
+    isRegularFileType,
+    isSymbolicLinkType,
+    isSocketType,
+    isWhiteoutType,
+    getRealDirType,
+    readDirStreamWith,
+    readDirStreamWithPtr,
+    DirStreamOffset(..),
     ) where
 
 import System.Posix.Directory.Common

--- a/System/Posix/Directory/PosixPath.hsc
+++ b/System/Posix/Directory/PosixPath.hsc
@@ -29,31 +29,15 @@ module System.Posix.Directory.PosixPath (
    -- * Reading directories
    Common.DirStream,
    Common.DirType( DtUnknown
-#ifdef CONST_DT_FIFO
-          , DtFifo
-#endif
-#ifdef CONST_DT_CHR
-          , DtChr
-#endif
-#ifdef CONST_DT_DIR
-          , DtDir
-#endif
-#ifdef CONST_DT_BLK
-          , DtBlk
-#endif
-#ifdef CONST_DT_REG
-          , DtReg
-#endif
-#ifdef CONST_DT_LNK
-          , DtLnk
-#endif
-#ifdef CONST_DT_SOCK
-          , DtSock
-#endif
-#ifdef CONST_DT_WHT
-          , DtWht
-#endif
-          ),
+                 , DtFifo
+                 , DtChr
+                 , DtDir
+                 , DtBlk
+                 , DtReg
+                 , DtLnk
+                 , DtSock
+                 , DtWht
+                 ),
    openDirStream,
    readDirStream,
    readDirStreamMaybe,

--- a/System/Posix/Directory/PosixPath.hsc
+++ b/System/Posix/Directory/PosixPath.hsc
@@ -28,16 +28,19 @@ module System.Posix.Directory.PosixPath (
 
    -- * Reading directories
    Common.DirStream,
-   Common.DirType( DtUnknown
-                 , DtFifo
-                 , DtChr
-                 , DtDir
-                 , DtBlk
-                 , DtReg
-                 , DtLnk
-                 , DtSock
-                 , DtWht
+   Common.DirType( UnknownType
+                 , NamedPipeType
+                 , CharacterDeviceType
+                 , DirectoryType
+                 , BlockDeviceType
+                 , RegularFileType
+                 , SymbolicLinkType
+                 , SocketType
+                 , WhiteoutType
                  ),
+   Common.isUnknownType, Common.isBlockDeviceType, Common.isCharacterDeviceType,
+   Common.isNamedPipeType, Common.isRegularFileType, Common.isDirectoryType,
+   Common.isSymbolicLinkType, Common.isSocketType, Common.isWhiteoutType,
    openDirStream,
    readDirStream,
    readDirStreamMaybe,
@@ -117,6 +120,9 @@ readDirStreamMaybe = Common.readDirStreamWith
 --   structure together with the entry's type (@d_type@) wrapped in a
 --   @Just (d_name, d_type)@ if an entry was read and @Nothing@ if
 --   the end of the directory stream was reached.
+--
+--   __Note__: The returned 'DirType' has some limitations; Please see its
+--   documentation.
 readDirStreamWithType :: Common.DirStream -> IO (Maybe (PosixPath, Common.DirType))
 readDirStreamWithType = Common.readDirStreamWith
   (\(Common.DirEnt dEnt) -> (,)

--- a/cbits/HsUnix.c
+++ b/cbits/HsUnix.c
@@ -104,6 +104,15 @@ char *__hscore_d_name( struct dirent* d )
   return (d->d_name);
 }
 
+char __hscore_d_type( struct dirent* d )
+{
+#ifdef HAVE_DIRENT_D_TYPE
+  return (d->d_type);
+#else
+  return 0;
+#endif
+}
+
 void __hscore_free_dirent(struct dirent *dEnt)
 {
 #if HAVE_READDIR_R && USE_READDIR_R

--- a/cbits/HsUnix.c
+++ b/cbits/HsUnix.c
@@ -109,7 +109,7 @@ char __hscore_d_type( struct dirent* d )
 #ifdef HAVE_DIRENT_D_TYPE
   return (d->d_type);
 #else
-  return 0;
+  return CONST_DT_UNKNOWN;
 #endif
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -28,10 +28,42 @@ AC_CHECK_HEADERS([bsd/libutil.h libutil.h pty.h utmp.h])
 AC_CHECK_HEADERS([termios.h time.h unistd.h utime.h])
 
 AC_STRUCT_DIRENT_D_TYPE
-FP_CHECK_CONSTS([DT_UNKNOWN DT_FIFO DT_CHR DT_DIR DT_BLK DT_REG DT_LNK DT_SOCK DT_WHT], [
+FP_CHECK_CONST([DT_UNKNOWN], [
 #if HAVE_STRUCT_DIRENT_D_TYPE
 #include <dirent.h>
-#endif])
+#endif], [-1])
+FP_CHECK_CONST([DT_FIFO], [
+#if HAVE_STRUCT_DIRENT_D_TYPE
+#include <dirent.h>
+#endif], [-2])
+FP_CHECK_CONST([DT_CHR], [
+#if HAVE_STRUCT_DIRENT_D_TYPE
+#include <dirent.h>
+#endif], [-3])
+FP_CHECK_CONST([DT_DIR], [
+#if HAVE_STRUCT_DIRENT_D_TYPE
+#include <dirent.h>
+#endif], [-4])
+FP_CHECK_CONST([DT_BLK], [
+#if HAVE_STRUCT_DIRENT_D_TYPE
+#include <dirent.h>
+#endif], [-5])
+FP_CHECK_CONST([DT_REG], [
+#if HAVE_STRUCT_DIRENT_D_TYPE
+#include <dirent.h>
+#endif], [-6])
+FP_CHECK_CONST([DT_LNK], [
+#if HAVE_STRUCT_DIRENT_D_TYPE
+#include <dirent.h>
+#endif], [-7])
+FP_CHECK_CONST([DT_SOCK], [
+#if HAVE_STRUCT_DIRENT_D_TYPE
+#include <dirent.h>
+#endif], [-8])
+FP_CHECK_CONST([DT_WHT], [
+#if HAVE_STRUCT_DIRENT_D_TYPE
+#include <dirent.h>
+#endif], [-9])
 
 AC_CHECK_FUNCS([getgrgid_r getgrnam_r getpwnam_r getpwuid_r getpwnam getpwuid])
 AC_CHECK_FUNCS([getpwent getgrent])

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,12 @@ AC_CHECK_HEADERS([sys/sysmacros.h])
 AC_CHECK_HEADERS([bsd/libutil.h libutil.h pty.h utmp.h])
 AC_CHECK_HEADERS([termios.h time.h unistd.h utime.h])
 
+AC_STRUCT_DIRENT_D_TYPE
+FP_CHECK_CONSTS([DT_UNKNOWN DT_FIFO DT_CHR DT_DIR DT_BLK DT_REG DT_LNK DT_SOCK DT_WHT], [
+#if HAVE_STRUCT_DIRENT_D_TYPE
+#include <dirent.h>
+#endif])
+
 AC_CHECK_FUNCS([getgrgid_r getgrnam_r getpwnam_r getpwuid_r getpwnam getpwuid])
 AC_CHECK_FUNCS([getpwent getgrent])
 AC_CHECK_FUNCS([lchown setenv sysconf unsetenv clearenv])

--- a/tests/ReadDirStream.hs
+++ b/tests/ReadDirStream.hs
@@ -11,9 +11,6 @@ import System.Posix.IO
 import Control.Exception as E
 import Test.Tasty.HUnit
 
-dir :: FilePath
-dir = "dir"
-
 emptyDirStream :: IO ()
 emptyDirStream = do
   cleanup
@@ -23,6 +20,11 @@ emptyDirStream = do
   closeDirStream dir_p
   cleanup
   entries @?= []
+  where
+    dir = "emptyDirStream"
+
+    cleanup = do
+      ignoreIOExceptions $ removeDirectory dir
 
 nonEmptyDirStream :: IO ()
 nonEmptyDirStream = do
@@ -34,6 +36,12 @@ nonEmptyDirStream = do
   closeDirStream dir_p
   cleanup
   entries @?= ["file"]
+  where
+    dir = "nonEmptyDirStream"
+
+    cleanup = do
+      ignoreIOExceptions $ removeLink $ dir ++ "/file"
+      ignoreIOExceptions $ removeDirectory dir
 
 dirStreamWithTypes :: IO ()
 dirStreamWithTypes = do
@@ -46,6 +54,13 @@ dirStreamWithTypes = do
   closeDirStream (fromDirStreamWithPath dir_p)
   cleanup
   Data.List.sort entries @?= [("somedir", DirectoryType), ("somefile", RegularFileType)]
+  where
+    dir = "dirStreamWithTypes"
+
+    cleanup = do
+      ignoreIOExceptions $ removeDirectory $ dir ++ "/somedir"
+      ignoreIOExceptions $ removeLink $ dir ++ "/somefile"
+      ignoreIOExceptions $ removeDirectory dir
 
 readDirStreamEntries :: DirStream -> IO [FilePath]
 readDirStreamEntries dir_p = do
@@ -64,11 +79,6 @@ readDirStreamEntriesWithTypes dir_p = do
     Just (".", _) -> readDirStreamEntriesWithTypes dir_p
     Just ("..", _) -> readDirStreamEntriesWithTypes dir_p
     Just ent -> (ent :) <$> readDirStreamEntriesWithTypes dir_p
-
-cleanup :: IO ()
-cleanup = do
-    ignoreIOExceptions $ removeLink $ dir ++ "/file"
-    ignoreIOExceptions $ removeDirectory dir
 
 ignoreIOExceptions :: IO () -> IO ()
 ignoreIOExceptions io = io `E.catch`

--- a/tests/ReadDirStream.hs
+++ b/tests/ReadDirStream.hs
@@ -1,0 +1,49 @@
+module ReadDirStream
+  ( emptyDirStream
+  , nonEmptyDirStream
+  ) where
+
+import System.Posix.Files
+import System.Posix.Directory
+import System.Posix.IO
+import Control.Exception as E
+import Test.Tasty.HUnit
+
+dir :: FilePath
+dir = "dir"
+
+emptyDirStream :: IO ()
+emptyDirStream = do
+  cleanup
+  createDirectory dir ownerReadMode
+  dir_p <- openDirStream dir
+  _ <- readDirStreamMaybe dir_p  -- Just "."
+  _ <- readDirStreamMaybe dir_p  -- Just ".."
+  ment <- readDirStreamMaybe dir_p
+  closeDirStream dir_p
+  cleanup
+  ment @?= Nothing
+
+nonEmptyDirStream :: IO ()
+nonEmptyDirStream = do
+  cleanup
+  createDirectory dir ownerModes
+  _ <- createFile (dir ++ "/file") ownerReadMode
+  dir_p <- openDirStream dir
+  -- We read three entries here since "." and "." are included in the dirstream
+  one <- readDirStreamMaybe dir_p
+  two <- readDirStreamMaybe dir_p
+  three <- readDirStreamMaybe dir_p
+  let ment = maximum [one, two, three]
+  closeDirStream dir_p
+  cleanup
+  ment @?= Just "file"
+
+cleanup :: IO ()
+cleanup = do
+    ignoreIOExceptions $ removeLink $ dir ++ "/file"
+    ignoreIOExceptions $ removeDirectory dir
+
+ignoreIOExceptions :: IO () -> IO ()
+ignoreIOExceptions io = io `E.catch`
+                        ((\_ -> return ()) :: E.IOException -> IO ())

--- a/tests/ReadDirStream.hs
+++ b/tests/ReadDirStream.hs
@@ -1,10 +1,8 @@
 module ReadDirStream
   ( emptyDirStream
   , nonEmptyDirStream
-  , dirStreamWithTypes
   ) where
 
-import qualified Data.List
 import System.Posix.Files
 import System.Posix.Directory
 import System.Posix.IO
@@ -43,25 +41,6 @@ nonEmptyDirStream = do
       ignoreIOExceptions $ removeLink $ dir ++ "/file"
       ignoreIOExceptions $ removeDirectory dir
 
-dirStreamWithTypes :: IO ()
-dirStreamWithTypes = do
-  cleanup
-  createDirectory dir ownerModes
-  createDirectory (dir ++ "/somedir") ownerModes
-  _ <- createFile (dir ++ "/somefile") ownerReadMode
-  dir_p <- openDirStreamWithPath dir
-  entries <- readDirStreamEntriesWithTypes dir_p
-  closeDirStream (fromDirStreamWithPath dir_p)
-  cleanup
-  Data.List.sort entries @?= [("somedir", DirectoryType), ("somefile", RegularFileType)]
-  where
-    dir = "dirStreamWithTypes"
-
-    cleanup = do
-      ignoreIOExceptions $ removeDirectory $ dir ++ "/somedir"
-      ignoreIOExceptions $ removeLink $ dir ++ "/somefile"
-      ignoreIOExceptions $ removeDirectory dir
-
 readDirStreamEntries :: DirStream -> IO [FilePath]
 readDirStreamEntries dir_p = do
   ment <- readDirStreamMaybe dir_p
@@ -70,15 +49,6 @@ readDirStreamEntries dir_p = do
     Just "." -> readDirStreamEntries dir_p
     Just ".." -> readDirStreamEntries dir_p
     Just ent -> (ent :) <$> readDirStreamEntries dir_p
-
-readDirStreamEntriesWithTypes :: DirStreamWithPath FilePath -> IO [(FilePath, DirType)]
-readDirStreamEntriesWithTypes dir_p = do
-  ment <- readDirStreamWithType dir_p
-  case ment of
-    Nothing -> return []
-    Just (".", _) -> readDirStreamEntriesWithTypes dir_p
-    Just ("..", _) -> readDirStreamEntriesWithTypes dir_p
-    Just ent -> (ent :) <$> readDirStreamEntriesWithTypes dir_p
 
 ignoreIOExceptions :: IO () -> IO ()
 ignoreIOExceptions io = io `E.catch`

--- a/tests/Test.hsc
+++ b/tests/Test.hsc
@@ -29,6 +29,7 @@ import Test.Tasty.QuickCheck
 import qualified FileStatus
 import qualified FileExtendedStatus
 import qualified FileStatusByteString
+import qualified ReadDirStream
 import qualified Signals001
 
 main :: IO ()
@@ -59,6 +60,9 @@ main = defaultMain $ testGroup "All"
     , posix005                     -- JS: missing "environ"
     , posix006                     -- JS: missing "time"
     , posix010                     -- JS: missing "sysconf"
+    , emptyDirStream
+    , nonEmptyDirStream
+    , dirStreamWithTypes
     ]
 #endif
   , testWithFilePath
@@ -274,6 +278,15 @@ testWithFilePath =
           ioProperty $ PPFP.withFilePath (PosixString ys)
             (\ptr -> (=== ys) <$> Sh.packCString ptr)
       ]
+
+emptyDirStream :: TestTree
+emptyDirStream = testCase "emptyDirStream" ReadDirStream.emptyDirStream
+
+nonEmptyDirStream :: TestTree
+nonEmptyDirStream = testCase "nonEmptyDirStream" ReadDirStream.nonEmptyDirStream
+
+dirStreamWithTypes :: TestTree
+dirStreamWithTypes = testCase "dirStreamWithTypes" ReadDirStream.dirStreamWithTypes
 
 -------------------------------------------------------------------------------
 -- Utils

--- a/tests/Test.hsc
+++ b/tests/Test.hsc
@@ -62,7 +62,6 @@ main = defaultMain $ testGroup "All"
     , posix010                     -- JS: missing "sysconf"
     , emptyDirStream
     , nonEmptyDirStream
-    , dirStreamWithTypes
     ]
 #endif
   , testWithFilePath
@@ -284,9 +283,6 @@ emptyDirStream = testCase "emptyDirStream" ReadDirStream.emptyDirStream
 
 nonEmptyDirStream :: TestTree
 nonEmptyDirStream = testCase "nonEmptyDirStream" ReadDirStream.nonEmptyDirStream
-
-dirStreamWithTypes :: TestTree
-dirStreamWithTypes = testCase "dirStreamWithTypes" ReadDirStream.dirStreamWithTypes
 
 -------------------------------------------------------------------------------
 -- Utils

--- a/unix.cabal
+++ b/unix.cabal
@@ -179,6 +179,7 @@ test-suite unix-tests
         FileExtendedStatus
         FileStatusByteString
         Signals001
+        ReadDirStream
     type: exitcode-stdio-1.0
     default-language: Haskell2010
     build-depends: base, bytestring, tasty, tasty-hunit, tasty-quickcheck, unix


### PR DESCRIPTION
This PR adds two new functions `readDirStreamWith` and `readDirStreamWithPtr`:
 * `readDirStreamWith` is a version of `readDirStreamMaybe` that takes a callback that is used to obtain the result from the pointer to the directory entry. This directory pointer is wrapped in a newtype called `DirEnt`. The function is intended to be used in cases where we know about the features of the installed libc: For example, glibc provides the information about the type of the directory entry directly in the dirent struct. Therefore it can be used directly without calling further functions and additional calls to stat(2).
Since those extensions to dirent are not covered by POSIX but widely used, we provide only the possibility to make use of those and do not add this functionality to `unix`.
 * `readDirStreamWithPtr` takes a pre-allocated pointer in addition to the other arguments of `readDirStreamWith`. This pointer is used to store the pointer of the dirent struct (if there is any) which can safe some allocations when you want to read a lot of directory entries as this pre-allocated pointer can be shared between the calls to the function.

In addition to that a small CPP bug was fixed which prevented compilation on my system. Also, some tests for the readDirStream functions were added.
