### PR TITLE
Use capi for syscalls that break under musl's handling of 64-bit time_t

### DIFF
--- a/System/Posix/DynamicLinker/Prim.hsc
+++ b/System/Posix/DynamicLinker/Prim.hsc
@@ -85,10 +85,17 @@ data RTLDFlags
   | RTLD_LOCAL
     deriving (Show, Read)
 
+#if defined(HAVE_DLFCN_H)
 foreign import capi unsafe "dlfcn.h dlopen" c_dlopen :: CString -> CInt -> IO (Ptr ())
 foreign import capi unsafe "dlfcn.h dlsym"  c_dlsym  :: Ptr () -> CString -> IO (FunPtr a)
 foreign import capi unsafe "dlfcn.h dlerror" c_dlerror :: IO CString
 foreign import capi unsafe "dlfcn.h dlclose" c_dlclose :: (Ptr ()) -> IO CInt
+#else
+foreign import ccall unsafe "dlopen" c_dlopen :: CString -> CInt -> IO (Ptr ())
+foreign import ccall unsafe "dlsym"  c_dlsym  :: Ptr () -> CString -> IO (FunPtr a)
+foreign import ccall unsafe "dlerror" c_dlerror :: IO CString
+foreign import ccall unsafe "dlclose" c_dlclose :: (Ptr ()) -> IO CInt
+#endif // HAVE_DLFCN_H
 
 packRTLDFlags :: [RTLDFlags] -> CInt
 packRTLDFlags flags = foldl (\ s f -> (packRTLDFlag f) .|. s) 0 flags

--- a/System/Posix/DynamicLinker/Prim.hsc
+++ b/System/Posix/DynamicLinker/Prim.hsc
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE Trustworthy #-}
 {-# OPTIONS_GHC -Wno-trustworthy-safe #-}
 
@@ -84,10 +85,10 @@ data RTLDFlags
   | RTLD_LOCAL
     deriving (Show, Read)
 
-foreign import ccall unsafe "dlopen" c_dlopen :: CString -> CInt -> IO (Ptr ())
-foreign import ccall unsafe "dlsym"  c_dlsym  :: Ptr () -> CString -> IO (FunPtr a)
-foreign import ccall unsafe "dlerror" c_dlerror :: IO CString
-foreign import ccall unsafe "dlclose" c_dlclose :: (Ptr ()) -> IO CInt
+foreign import capi unsafe "dlfcn.h dlopen" c_dlopen :: CString -> CInt -> IO (Ptr ())
+foreign import capi unsafe "dlfcn.h dlsym"  c_dlsym  :: Ptr () -> CString -> IO (FunPtr a)
+foreign import capi unsafe "dlfcn.h dlerror" c_dlerror :: IO CString
+foreign import capi unsafe "dlfcn.h dlclose" c_dlclose :: (Ptr ()) -> IO CInt
 
 packRTLDFlags :: [RTLDFlags] -> CInt
 packRTLDFlags flags = foldl (\ s f -> (packRTLDFlag f) .|. s) 0 flags

--- a/System/Posix/DynamicLinker/Prim.hsc
+++ b/System/Posix/DynamicLinker/Prim.hsc
@@ -86,15 +86,15 @@ data RTLDFlags
     deriving (Show, Read)
 
 #if defined(HAVE_DLFCN_H)
-foreign import capi unsafe "dlfcn.h dlopen" c_dlopen :: CString -> CInt -> IO (Ptr ())
+foreign import capi safe "dlfcn.h dlopen" c_dlopen :: CString -> CInt -> IO (Ptr ())
 foreign import capi unsafe "dlfcn.h dlsym"  c_dlsym  :: Ptr () -> CString -> IO (FunPtr a)
 foreign import capi unsafe "dlfcn.h dlerror" c_dlerror :: IO CString
-foreign import capi unsafe "dlfcn.h dlclose" c_dlclose :: (Ptr ()) -> IO CInt
+foreign import capi safe "dlfcn.h dlclose" c_dlclose :: (Ptr ()) -> IO CInt
 #else
-foreign import ccall unsafe "dlopen" c_dlopen :: CString -> CInt -> IO (Ptr ())
+foreign import ccall safe "dlopen" c_dlopen :: CString -> CInt -> IO (Ptr ())
 foreign import ccall unsafe "dlsym"  c_dlsym  :: Ptr () -> CString -> IO (FunPtr a)
 foreign import ccall unsafe "dlerror" c_dlerror :: IO CString
-foreign import ccall unsafe "dlclose" c_dlclose :: (Ptr ()) -> IO CInt
+foreign import ccall safe "dlclose" c_dlclose :: (Ptr ()) -> IO CInt
 #endif // HAVE_DLFCN_H
 
 packRTLDFlags :: [RTLDFlags] -> CInt

--- a/System/Posix/Files/Common.hsc
+++ b/System/Posix/Files/Common.hsc
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE Trustworthy #-}
 
 -----------------------------------------------------------------------------
@@ -452,12 +453,12 @@ toCTimeSpec t = CTimeSpec (CTime sec) (truncate $ 10^(9::Int) * frac)
 #endif
 
 #ifdef HAVE_UTIMENSAT
-foreign import ccall unsafe "utimensat"
+foreign import capi unsafe "sys/stat.h utimensat"
     c_utimensat :: CInt -> CString -> Ptr CTimeSpec -> CInt -> IO CInt
 #endif
 
 #if HAVE_FUTIMENS
-foreign import ccall unsafe "futimens"
+foreign import capi unsafe "sys/stat.h futimens"
     c_futimens :: CInt -> Ptr CTimeSpec -> IO CInt
 #endif
 
@@ -480,16 +481,16 @@ toCTimeVal t = CTimeVal sec (truncate $ 10^(6::Int) * frac)
     (sec, frac) = if (frac' < 0) then (sec' - 1, frac' + 1) else (sec', frac')
     (sec', frac') = properFraction $ toRational t
 
-foreign import ccall unsafe "utimes"
+foreign import capi unsafe "sys/time.h utimes"
     c_utimes :: CString -> Ptr CTimeVal -> IO CInt
 
 #ifdef HAVE_LUTIMES
-foreign import ccall unsafe "lutimes"
+foreign import capi unsafe "sys/time.h lutimes"
     c_lutimes :: CString -> Ptr CTimeVal -> IO CInt
 #endif
 
 #if HAVE_FUTIMES
-foreign import ccall unsafe "futimes"
+foreign import capi unsafe "sys/time.h futimes"
     c_futimes :: CInt -> Ptr CTimeVal -> IO CInt
 #endif
 


### PR DESCRIPTION
I maintain a [repo with builds of GHC](https://github.com/redneb/ghc-alt-libc) for the musl C standard library and I encountered a subtle bug of this library that affects GHC under 32-bit architectures with musl.

In 32-bit architectures, there was a transition where the C type `time_t` was redefined to be 64-bit in order to address the Y2038 problem. The way this was handled by musl was by introducing new versions of all affected syscalls that work with 64-bit `time_t` (e.g. `utimensat_time64` is like `utimensat` but with 64-bit `time_t`). In addition, a redirect was introduced to create an alias of the new versions of these functions under the old name (e.g. [here's the redirection](https://git.musl-libc.org/cgit/musl/tree/include/sys/stat.h?id=dc9285ad1dc19349c407072cc48ba70dab86de45#n119) for `utimensat`).

The problem is that this redirection is defined as a C macro in a C header file and as such, it does not get picked by GHC when the foreign function import is done via `ccall`, but works just fine when `capi` is used. So this PR changes all affected syscalls to be imported with `capi`, which should be a fairly uncontroversial change.