### PR TITLE
semaphore: Teach semThreadWait to use semWait with threaded RTS

### DIFF
--- a/test-wasm32-wasi.mjs
+++ b/test-wasm32-wasi.mjs
@@ -8,7 +8,7 @@ const my_execFile = util.promisify(child_process.execFile);
 let warns_count = 0;
 for (const f of await fs.promises.readdir("tests")) {
   // odd linker errors
-  if (f === "Semaphore001.hs") continue;
+  if (f.startsWith('Semaphore')) continue;
   // Find self-contained test cases (aka doesn't rely on tasty)
   if (!f.endsWith(".hs")) continue;
   const s = await fs.promises.readFile(`tests/${f}`, "utf-8");

--- a/tests/Semaphore002.hs
+++ b/tests/Semaphore002.hs
@@ -1,0 +1,15 @@
+module Main (main) where
+
+import Control.Concurrent
+import System.Posix
+
+main :: IO ()
+main = do
+  sem <- semOpen "/test" OpenSemFlags {semCreate = True, semExclusive = False} stdFileMode 0
+  forkIO $ do
+      threadDelay (1000*1000)
+      semPost sem
+
+  -- This should succeed after 1 second.
+  semThreadWait sem
+  semPost sem

--- a/tests/Semaphore002.hs
+++ b/tests/Semaphore002.hs
@@ -6,7 +6,7 @@ import System.Posix
 main :: IO ()
 main = do
   sem <- semOpen "/test" OpenSemFlags {semCreate = True, semExclusive = False} stdFileMode 0
-  forkIO $ do
+  _ <- forkIO $ do
       threadDelay (1000*1000)
       semPost sem
 

--- a/unix.cabal
+++ b/unix.cabal
@@ -262,3 +262,11 @@ test-suite Semaphore001
     default-language: Haskell2010
     build-depends: base, unix
     ghc-options: -Wall
+
+test-suite Semaphore002
+    hs-source-dirs: tests
+    main-is: Semaphore002.hs
+    type: exitcode-stdio-1.0
+    default-language: Haskell2010
+    build-depends: base, unix
+    ghc-options: -Wall -threaded


### PR DESCRIPTION
semThreadWait uses a rather atrocious polling loop to avoid
blocking, which we block the entire program when using the non-threaded
runtime. However, this is unnecessary in the threaded runtime, where we
can instead simply block in semWait.

Fixes #253