### PR TITLE
Add semWaitInterruptible

### DIFF
--- a/tests/Semaphore001.hs
+++ b/tests/Semaphore001.hs
@@ -4,6 +4,6 @@ import System.Posix
 
 main :: IO ()
 main = do
-  sem <- semOpen "/test" OpenSemFlags {semCreate = True, semExclusive = False} stdFileMode 1
+  sem <- semOpen "/test-001" OpenSemFlags {semCreate = True, semExclusive = False} stdFileMode 1
   semThreadWait sem
   semPost sem

--- a/tests/Semaphore002.hs
+++ b/tests/Semaphore002.hs
@@ -5,7 +5,7 @@ import System.Posix
 
 main :: IO ()
 main = do
-  sem <- semOpen "/test" OpenSemFlags {semCreate = True, semExclusive = False} stdFileMode 0
+  sem <- semOpen "/test-002" OpenSemFlags {semCreate = True, semExclusive = False} stdFileMode 0
   _ <- forkIO $ do
       threadDelay (1000*1000)
       semPost sem

--- a/tests/SemaphoreInterrupt.hs
+++ b/tests/SemaphoreInterrupt.hs
@@ -1,0 +1,32 @@
+module Main (main) where
+
+import Control.Concurrent
+import Control.Monad
+import Data.IORef
+import System.Posix
+
+main :: IO ()
+main = do
+
+  sem <- semOpen "/test" OpenSemFlags {semCreate = True, semExclusive = False} stdFileMode 0
+  ref <- newIORef False
+  _ <- forkIO $ do
+    res <- semWaitInterruptible sem
+    writeIORef ref res
+  threadDelay 100000 -- 100 ms
+  semPost sem
+  threadDelay 100000 -- 100 ms
+  succ1 <- readIORef ref
+  unless succ1 $
+    error "SemaphoreInterrupt: semWaitInterruptible failed"
+
+  writeIORef ref False
+  tid <- forkIO $ do
+    res <- semWaitInterruptible sem
+    writeIORef ref res
+  threadDelay 100000 -- 100 ms
+  killThread tid
+  threadDelay 100000 -- 100 ms
+  succ2 <- readIORef ref
+  when succ2 $
+    error "SemaphoreInterrupt: semWaitInterruptible not interrupted"

--- a/tests/SemaphoreInterrupt.hs
+++ b/tests/SemaphoreInterrupt.hs
@@ -8,7 +8,7 @@ import System.Posix
 main :: IO ()
 main = do
 
-  sem <- semOpen "/test" OpenSemFlags {semCreate = True, semExclusive = False} stdFileMode 0
+  sem <- semOpen "/test-interrupt" OpenSemFlags {semCreate = True, semExclusive = False} stdFileMode 0
   ref <- newIORef False
   _ <- forkIO $ do
     res <- semWaitInterruptible sem

--- a/unix.cabal
+++ b/unix.cabal
@@ -270,3 +270,11 @@ test-suite Semaphore002
     default-language: Haskell2010
     build-depends: base, unix
     ghc-options: -Wall -threaded
+
+test-suite SemaphoreInterrupt
+    hs-source-dirs: tests
+    main-is: SemaphoreInterrupt.hs
+    type: exitcode-stdio-1.0
+    default-language: Haskell2010
+    build-depends: base, unix
+    ghc-options: -Wall -threaded


### PR DESCRIPTION
The `semWaitInterruptible` function allows us to start a thread that blocks on the semaphore but can be interrupted.