### PR TITLE
Avoid `Data.List.{head,tail}`

### DIFF
--- a/.github/workflows/ci-wasm32-wasi.yml
+++ b/.github/workflows/ci-wasm32-wasi.yml
@@ -12,7 +12,7 @@ jobs:
       - name: setup-ghc-wasm32-wasi
         run: |
           pushd $(mktemp -d)
-          curl -L https://github.com/tweag/ghc-wasm32-wasi/archive/refs/heads/master.tar.gz | tar xz --strip-components=1
+          curl -L https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/archive/master/ghc-wasm-meta-master.tar.gz | tar xz --strip-components=1
           ./setup.sh
           ~/.ghc-wasm32-wasi/add_to_github_path.sh
           popd

--- a/System/Posix/DynamicLinker/Module.hsc
+++ b/System/Posix/DynamicLinker/Module.hsc
@@ -56,6 +56,7 @@ where
 
 #include "HsUnix.h"
 
+import Prelude hiding (head, tail)
 import System.Posix.DynamicLinker
 import System.Posix.DynamicLinker.Common
 import Foreign.Ptr      ( Ptr, nullPtr, FunPtr )
@@ -101,9 +102,9 @@ withModule :: Maybe String
 withModule mdir file flags p = do
   let modPath = case mdir of
                   Nothing -> file
-                  Just dir  -> dir ++ if ((head (reverse dir)) == '/')
-                                       then file
-                                       else ('/':file)
+                  Just dir  -> dir ++ case reverse dir of
+                    '/' : _ -> file
+                    _ -> '/' : file
   modu <- moduleOpen modPath flags
   result <- p modu
   moduleClose modu


### PR DESCRIPTION
CLC has approved the proposal to add `{-# WARNING #-}` to `Data.List.{head,tail}` (https://github.com/haskell/core-libraries-committee/issues/87). It means that usage of `head` and `tail` will emit compile-time warnings.

This patch eliminates the only usage of `head` in `unix`.