### PR TITLE
Avoid `Data.List.{head,tail}`

### DIFF
--- a/.github/workflows/ci-wasm32-wasi.yml
+++ b/.github/workflows/ci-wasm32-wasi.yml
@@ -12,16 +12,16 @@ jobs:
       - name: setup-ghc-wasm32-wasi
         run: |
           pushd $(mktemp -d)
-          curl -L https://github.com/tweag/ghc-wasm32-wasi/archive/refs/heads/master.tar.gz | tar xz --strip-components=1
+          curl -L https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/archive/master/ghc-wasm-meta-master.tar.gz | tar xz --strip-components=1
           ./setup.sh
-          ~/.ghc-wasm32-wasi/add_to_github_path.sh
+          ~/.ghc-wasm/add_to_github_path.sh
           popd
 
       - uses: actions/checkout@v3
 
       - name: test
         run: |
-          cp ~/.ghc-wasm32-wasi/wasi-sdk/share/misc/config.* .
+          cp ~/.ghc-wasm/wasi-sdk/share/misc/config.* .
           autoreconf -i
 
           wasm32-wasi-cabal --project-file=cabal.project.wasm32-wasi build

--- a/System/Posix/DynamicLinker/Module.hsc
+++ b/System/Posix/DynamicLinker/Module.hsc
@@ -56,6 +56,7 @@ where
 
 #include "HsUnix.h"
 
+import Prelude hiding (head, tail)
 import System.Posix.DynamicLinker
 import System.Posix.DynamicLinker.Common
 import Foreign.Ptr      ( Ptr, nullPtr, FunPtr )
@@ -101,7 +102,7 @@ withModule :: Maybe String
 withModule mdir file flags p = do
   let modPath = case mdir of
                   Nothing -> file
-                  Just dir  -> dir ++ if ((head (reverse dir)) == '/')
+                  Just dir  -> dir ++ if last dir == '/'
                                        then file
                                        else ('/':file)
   modu <- moduleOpen modPath flags


### PR DESCRIPTION
CLC has approved the proposal to add `{-# WARNING #-}` to `Data.List.{head,tail}` (https://github.com/haskell/core-libraries-committee/issues/87). It means that usage of `head` and `tail` will emit compile-time warnings.

This patch eliminates the only usage of `head` in `unix`.