### PR TITLE
Add NetBSD CI job

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,3 +23,20 @@ task:
     - cabal update
     - autoreconf -i
     - cabal test --test-show-details=direct
+
+task:
+  name: NetBSD
+  compute_engine_instance:
+    image_project: pg-ci-images
+    image: family/pg-ci-netbsd-vanilla-9-2
+    platform: netbsd
+  install_script:
+    - export PKG_PATH="http://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All/"
+    - pkg_add ghc cabal-install git autoconf
+  script:
+    - export CABAL_DIR=/tmp/.cabal
+    - ghc --version
+    - cabal --version
+    - cabal update
+    - autoreconf -i
+    - cabal test --test-show-details=direct


### PR DESCRIPTION
@blackgnezdo any idea what's wrong with Cabal?
```
ghc --version
The Glorious Glasgow Haskell Compilation System, version 9.2.4
cabal --version
cabal-install version 3.6.2.0
compiled using version 3.6.3.0 of the Cabal library 
cabal update
Config file path source is default config file.
Config file //.cabal/config not found.
Writing default configuration to //.cabal/config
Downloading the latest package list from hackage.haskell.org
Package list of hackage.haskell.org is up to date at index-state 
export AUTOCONF_VERSION=2.71
autoreconf -i
cabal test --test-show-details=direct
cabal: Could not read index. Did you call 'checkForUpdates'?
```