### PR TITLE
CI: include GHC 9.4, bump actions to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macOS-latest]
+        os: [ubuntu-22.04, macOS-latest]
         ghc: ['9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2']
     steps:
     - uses: actions/checkout@v3
+    - name: Install prerequisites for GHC 8.2 on ubuntu-22.04
+      if: runner.os == 'Linux' && matrix.ghc == '8.2'
+      run: |
+        sudo apt-get install libncurses5 libtinfo5
     - uses: haskell/actions/setup@v2
       id: setup-haskell-cabal
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: ci
 on:
-  push:
-    branches: [ master, ci-* ]
-  pull_request:
-    branches: [ master, ci-* ]
+  - push
+  - pull_request
 
 defaults:
   run:
@@ -13,7 +11,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-22.04, macOS-latest]
         ghc: ['9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         apt-get update -y
         apt-get install -y autoconf build-essential zlib1g-dev libgmp-dev curl
         curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v1
     - name: Test
       run: |
         source ~/.ghcup/env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: ci
 on:
-  - push
-  - pull_request
+  push:
+    branches: [ master, ci-* ]
+  pull_request:
+    branches: [ master, ci-* ]
 
 defaults:
   run:
@@ -11,9 +13,9 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-20.04, macOS-latest]
         ghc: ['9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2']
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        ghc: ['9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2']
+        ghc: ['9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2']
     steps:
-    - uses: actions/checkout@v2
-    - uses: haskell/actions/setup@v1
+    - uses: actions/checkout@v3
+    - uses: haskell/actions/setup@v2
       id: setup-haskell-cabal
       with:
         ghc-version: ${{ matrix.ghc }}
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       name: Cache cabal stuff
       with:
         path: |
@@ -50,7 +50,7 @@ jobs:
       run: |
         yum install -y gcc gmp gmp-devel make ncurses ncurses-compat-libs xz perl autoconf
         curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Test
       run: |
         source ~/.ghcup/env
@@ -69,7 +69,7 @@ jobs:
       run: |
         dnf install -y gcc gmp gmp-devel make ncurses ncurses-compat-libs xz perl autoconf
         curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Test
       run: |
         source ~/.ghcup/env
@@ -89,7 +89,7 @@ jobs:
         apt-get update -y
         apt-get install -y autoconf build-essential zlib1g-dev libgmp-dev curl
         curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Test
       run: |
         source ~/.ghcup/env
@@ -106,8 +106,8 @@ jobs:
       matrix:
         arch: ['armv7', 'aarch64']
     steps:
-    - uses: actions/checkout@v2
-    - uses: uraimo/run-on-arch-action@v2.1.1
+    - uses: actions/checkout@v3
+    - uses: uraimo/run-on-arch-action@v2
       timeout-minutes: 120
       with:
         arch: ${{ matrix.arch }}


### PR DESCRIPTION
Re: 
- #264

CI: include GHC 9.4, bump actions to latest version (where possible).
~~Had to stick to ubuntu-20.04 as e.g. 8.2.2 does not install on 22.04.~~

SQUASH me!