### PR TITLE
Bump bounds to accommodate base-4.18

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -69,7 +69,7 @@ library
         buildable: False
 
     build-depends:
-        base        >= 4.10    && < 4.18,
+        base        >= 4.10    && < 4.19,
         bytestring  >= 0.9.2   && < 0.12,
         filepath    >= 1.4.100.0 && < 1.5,
         time        >= 1.2     && < 1.13


### PR DESCRIPTION
In service of GHC 9.6.1.