### PR TITLE
Add missing autoconf checks for chown/fchdir/fchmod

### DIFF
--- a/System/Posix/Files.hsc
+++ b/System/Posix/Files.hsc
@@ -108,7 +108,7 @@ import Data.Monoid ((<>))
 
 import Data.Time.Clock.POSIX (POSIXTime)
 
-#if !defined(HAVE_MKNOD)
+#if !defined(HAVE_MKNOD) || !defined(HAVE_CHOWN)
 import System.IO.Error ( ioeSetLocation )
 import GHC.IO.Exception ( unsupportedOperation )
 #endif
@@ -323,6 +323,8 @@ foreign import ccall unsafe "rename"
 -- -----------------------------------------------------------------------------
 -- chown()
 
+#if defined(HAVE_CHOWN)
+
 -- | @setOwnerAndGroup path uid gid@ changes the owner and group of @path@ to
 -- @uid@ and @gid@, respectively.
 --
@@ -336,6 +338,14 @@ setOwnerAndGroup name uid gid = do
 
 foreign import ccall unsafe "chown"
   c_chown :: CString -> CUid -> CGid -> IO CInt
+
+#else
+
+{-# WARNING setOwnerAndGroup "operation will throw 'IOError' \"unsupported operation\" (CPP guard: @#if HAVE_CHOWN@)" #-}
+setOwnerAndGroup :: FilePath -> UserID -> GroupID -> IO ()
+setOwnerAndGroup _ _ _ = ioError (ioeSetLocation unsupportedOperation "setOwnerAndGroup")
+
+#endif // HAVE_CHOWN
 
 #if HAVE_LCHOWN
 -- | Acts as 'setOwnerAndGroup' but does not follow symlinks (and thus

--- a/System/Posix/Files/PosixString.hsc
+++ b/System/Posix/Files/PosixString.hsc
@@ -107,7 +107,7 @@ import System.Posix.PosixPath.FilePath
 
 import Data.Time.Clock.POSIX (POSIXTime)
 
-#if !defined(HAVE_MKNOD)
+#if !defined(HAVE_MKNOD) || !defined(HAVE_CHOWN)
 import System.IO.Error ( ioeSetLocation )
 import GHC.IO.Exception ( unsupportedOperation )
 #endif
@@ -316,6 +316,8 @@ foreign import ccall unsafe "rename"
 -- -----------------------------------------------------------------------------
 -- chown()
 
+#if defined(HAVE_CHOWN)
+
 -- | @setOwnerAndGroup path uid gid@ changes the owner and group of @path@ to
 -- @uid@ and @gid@, respectively.
 --
@@ -329,6 +331,14 @@ setOwnerAndGroup name uid gid = do
 
 foreign import ccall unsafe "chown"
   c_chown :: CString -> CUid -> CGid -> IO CInt
+
+#else
+
+{-# WARNING setOwnerAndGroup "operation will throw 'IOError' \"unsupported operation\" (CPP guard: @#if HAVE_CHOWN@)" #-}
+setOwnerAndGroup :: PosixPath -> UserID -> GroupID -> IO ()
+setOwnerAndGroup _ _ _ = ioError (ioeSetLocation unsupportedOperation "setOwnerAndGroup")
+
+#endif // HAVE_CHOWN
 
 #if HAVE_LCHOWN
 -- | Acts as 'setOwnerAndGroup' but does not follow symlinks (and thus

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,7 @@ AC_CHECK_FUNCS([mknod])
 AC_CHECK_FUNCS([mkstemp])
 AC_CHECK_FUNCS([pipe])
 AC_CHECK_FUNCS([times])
+AC_CHECK_FUNCS([chown fchdir fchmod])
 
 AC_CHECK_TYPE([struct rlimit],[AC_DEFINE([HAVE_STRUCT_RLIMIT],[1],[HAVE_STRUCT_RLIMIT])],[],[#include <sys/resource.h>])
 


### PR DESCRIPTION
These are not present in wasm32-wasi, and is needed for fixing GHC #22589.