### PR TITLE
CI: haskell/action/setup@v2.0.3 makes workaround obsolete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
         ghc: ['9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2']
     steps:
     - uses: actions/checkout@v3
-    - name: Install prerequisites for GHC 8.2 on ubuntu-22.04
-      if: runner.os == 'Linux' && matrix.ghc == '8.2'
-      run: |
-        sudo apt-get install libncurses5 libtinfo5
     - uses: haskell/actions/setup@v2
       id: setup-haskell-cabal
       with:


### PR DESCRIPTION
Remove the recent workaround `haskell/action/setup` not installing the prerequisites for GHC-8.2 on `ubuntu-22.04`.

This is my guinea pig of whether my fix in `haskell/action/setup@v2.0.3` works.  It does.
The relevant CI instance: https://github.com/haskell/unix/actions/runs/3694217152/jobs/6255145655

Merge this if you want things cleaned up.
(I am neutral.)