### PR TITLE
Allow bytestring-0.12

### DIFF
--- a/System/Posix/Env/ByteString.hsc
+++ b/System/Posix/Env/ByteString.hsc
@@ -42,7 +42,7 @@ import System.Posix.Env ( clearEnv )
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
 import Data.ByteString (ByteString)
-import Data.ByteString.Internal (ByteString (PS), memcpy)
+import Data.ByteString.Internal (ByteString (PS))
 
 import qualified System.Posix.Env.Internal as Internal
 
@@ -133,7 +133,7 @@ putEnv (PS fp o l) = withForeignPtr fp $ \p -> do
   --
   -- hence we must not free the buffer
   buf <- mallocBytes (l+1)
-  memcpy buf (p `plusPtr` o) l
+  copyBytes buf (p `plusPtr` o) l
   pokeByteOff buf l (0::Word8)
   throwErrnoIfMinus1_ "putenv" (c_putenv (castPtr buf))
 

--- a/unix.cabal
+++ b/unix.cabal
@@ -70,7 +70,7 @@ library
 
     build-depends:
         base        >= 4.10    && < 4.20,
-        bytestring  >= 0.9.2   && < 0.12,
+        bytestring  >= 0.9.2   && < 0.13,
         filepath    >= 1.4.100.0 && < 1.5,
         time        >= 1.2     && < 1.13
 


### PR DESCRIPTION
`unix` does not use any of the functions that have changed behavior in `bytestring-0.12.0.0`, so the bound-bump is safe. (See the [changelog](https://hackage.haskell.org/package/bytestring-0.12.0.0/changelog).)

I've also replaced the one use of the now-deprecated `Data.ByteString.Internal.memcpy` with the equivalent `Foreign.Marshal.Utils.copyBytes`.
