### PR TITLE
Make error strings consistent

### DIFF
--- a/System/Posix/PosixPath/FilePath.hsc
+++ b/System/Posix/PosixPath/FilePath.hsc
@@ -40,12 +40,11 @@ import Foreign.C hiding (
 
 import System.OsPath.Types
 import Control.Monad
-import GHC.IO.Encoding.UTF8 ( mkUTF8 )
-import GHC.IO.Encoding.Failure ( CodingFailureMode(..) )
-import System.OsPath.Posix
+import System.OsPath.Posix as PS
 import System.OsPath.Data.ByteString.Short
 import Prelude hiding (FilePath)
 import System.OsString.Internal.Types (PosixString(..))
+
 #if !MIN_VERSION_base(4, 11, 0)
 import Data.Monoid ((<>))
 #endif
@@ -136,5 +135,5 @@ throwErrnoTwoPathsIfMinus1_  loc path1 path2 =
 
 
 _toStr :: PosixPath -> String
-_toStr fp = either (error . show) id $ decodeWith (mkUTF8 TransliterateCodingFailure) fp
+_toStr = fmap PS.toChar . PS.unpack
 


### PR DESCRIPTION
System.Posix.ByteString.FilePath just unpacks, while System.Posix.PosixPath.FilePath tried to be smart and decode with UTF (without failing).

This divergence was discussed here:

* https://github.com/haskell/unix/pull/279
* https://github.com/haskell/core-libraries-committee/issues/189

----

Although the discussion at the CLC tracker hasn't come to a conclusion yet, I'm setting this up as the favorite approach so far. I suggest that we also augment the documentation in base.

@vdukhovni @Bodigrim 