### PR TITLE
Release unix-2.8.2.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog for [`unix` package](http://hackage.haskell.org/package/unix)
 
+## 2.8.2.0 *Sep 2023*
+
+  * Bump bounds to accomodate `base-4.19` and `bytestring-0.12`.
+
+  * Ensure that `FilePath`s don't contain interior `NUL`s.
+
+  * JavaScript backend: add support for `utimes` / `lutimes` / `futimes`.
+
 ## 2.8.1.1 *Mar 2023*
   * Fix `System.Posix.Env.ByteString.getEnvironment` segfaulting on empty environment
 

--- a/unix.cabal
+++ b/unix.cabal
@@ -1,6 +1,6 @@
 cabal-version:  1.12
 name:           unix
-version:        2.8.1.1
+version:        2.8.2.0
 -- NOTE: Don't forget to update ./changelog.md
 
 license:        BSD3


### PR DESCRIPTION
We have to make a release for upcoming GHC 9.8, ideally asap. Seems there is nothing outstanding, so just updated the changelog and bumped the version.

Cf. https://gitlab.haskell.org/ghc/ghc/-/issues/23926#note_524594

@hasufell @hs-viktor @vdukhovni 