### PR TITLE
Fix `withFilePath`

### DIFF
--- a/System/Posix/ByteString/FilePath.hsc
+++ b/System/Posix/ByteString/FilePath.hsc
@@ -153,7 +153,8 @@ decodeWithBasePosix ba = B.useAsCStringLen ba $ \fp -> peekFilePathPosix fp
 -- | Wrapper around 'useAsCString', checking the encoded 'FilePath' for internal NUL octets as these are
 -- disallowed in POSIX filepaths. See https://gitlab.haskell.org/ghc/ghc/-/issues/13660
 useAsCStringSafe :: RawFilePath -> (CString -> IO a) -> IO a
-useAsCStringSafe path f = useAsCStringLen path $ \(ptr, len) -> do
+useAsCStringSafe path f = useAsCString path $ \ptr -> do
+    let len = B.length path
     clen <- c_strlen ptr
     if clen == fromIntegral len
         then f ptr

--- a/System/Posix/PosixPath/FilePath.hsc
+++ b/System/Posix/PosixPath/FilePath.hsc
@@ -45,7 +45,7 @@ import Data.ByteString.Internal (c_strlen)
 import Control.Monad
 import Control.Exception
 import System.OsPath.Posix as PS
-import System.OsPath.Data.ByteString.Short
+import System.OsPath.Data.ByteString.Short as BSS
 import Prelude hiding (FilePath)
 import System.OsString.Internal.Types (PosixString(..), pattern PS)
 import GHC.IO.Exception
@@ -147,7 +147,8 @@ _toStr = fmap PS.toChar . PS.unpack
 -- | Wrapper around 'useAsCString', checking the encoded 'FilePath' for internal NUL octets as these are
 -- disallowed in POSIX filepaths. See https://gitlab.haskell.org/ghc/ghc/-/issues/13660
 useAsCStringSafe :: PosixPath -> (CString -> IO a) -> IO a
-useAsCStringSafe pp@(PS path) f = useAsCStringLen path $ \(ptr, len) -> do
+useAsCStringSafe pp@(PS path) f = useAsCString path $ \ptr -> do
+    let len = BSS.length path
     clen <- c_strlen ptr
     if clen == fromIntegral len
         then f ptr

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`unix` package](http://hackage.haskell.org/package/unix)
 
+## 2.8.2.1 *Sep 2023*
+
+  * Fix UB bug in `withFilePath` that causes it to error out (introduced in 2.8.2.0) wrt [#295](https://github.com/haskell/unix/issues/295)
+
 ## 2.8.2.0 *Sep 2023*
 
   * Bump bounds to accomodate `base-4.19` and `bytestring-0.12`.

--- a/unix.cabal
+++ b/unix.cabal
@@ -1,6 +1,6 @@
 cabal-version:  1.12
 name:           unix
-version:        2.8.2.0
+version:        2.8.2.1
 -- NOTE: Don't forget to update ./changelog.md
 
 license:        BSD3


### PR DESCRIPTION
https://github.com/haskell/cabal/pull/9241

@Bodigrim we'll need another release. This bug was introduced by 2.8.2.0, so maybe we can mark it as deprecated on hackage?