### PR TITLE
Don't `foreign import` `environ`

### DIFF
--- a/System/Posix/Env/Internal.hsc
+++ b/System/Posix/Env/Internal.hsc
@@ -22,8 +22,11 @@ getCEnviron = nsGetEnviron >>= peek
 foreign import ccall unsafe "_NSGetEnviron"
    nsGetEnviron :: IO (Ptr (Ptr CString))
 #else
-getCEnviron = peek c_environ_p
+getCEnviron = _getCEnviron
 
-foreign import ccall unsafe "&environ"
-   c_environ_p :: Ptr (Ptr CString)
+-- N.B. we cannot import `environ` directly in Haskell as it may be a weak symbol
+-- which requires special treatment by the compiler, which GHC is not equipped to
+-- provide. See GHC #24011.
+foreign import ccall unsafe "__hsunix_get_environ"
+   _getCEnviron :: IO (Ptr CString)
 #endif

--- a/cbits/HsUnix.c
+++ b/cbits/HsUnix.c
@@ -8,6 +8,8 @@
 
 #include "HsUnix.h"
 
+char **__hsunix_get_environ (void) {return environ;}
+
 #ifdef HAVE_RTLDNEXT
 void *__hsunix_rtldNext (void) {return RTLD_NEXT;}
 #endif


### PR DESCRIPTION
`musl` defines the `environ` symbol as a weak alias, which on AArch64 requires particular treatment by the compiler. As GHC doesn't have access to the prototype of the symbol, it doesn't know that this treatment is necessary and consequently we emit assembly that the linker will choke on.

Fixes [GHC #24011](https://gitlab.haskell.org/ghc/ghc/-/issues/24011).