### PR TITLE
Make CI green again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install
       run: |
         yum install -y gcc gmp gmp-devel make ncurses ncurses-compat-libs xz perl autoconf
-        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_GHC_VERSION=9.2.8 sh
     - uses: actions/checkout@v3
     - name: Test
       run: |
@@ -92,7 +92,7 @@ jobs:
       run: |
         apt-get update -y
         apt-get install -y autoconf build-essential zlib1g-dev libgmp-dev curl
-        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 sh
     - uses: actions/checkout@v1
     - name: Test
       run: |


### PR DESCRIPTION
* Fix i386 job, otherwise it fails with
```
[ Error ] [
[ ...   ] Set error was: The version 2.11.1 of the tool stack is not installed.
[ Error ] Also check the logs in /github/home/.ghcup/logs
```
* Fix CentOS job, it seems something is off with GHC 9.4.7 bindist, so let's stick to the previous recommended version:

```
[ Info  ] Installing GHC (this may take a while)
[ Error ] [./configure",
[ ...   ]                              "--prefix=/github/home/.ghcup/ghc/9.4.7"] failed with exit code 1.
```