### PR TITLE
Bump time bound to accomodate 1.14

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -74,7 +74,7 @@ library
         buildable: False
 
     build-depends:
-        base        >= 4.12.0.0  && < 4.20,
+        base        >= 4.12.0.0  && < 4.21,
         bytestring  >= 0.9.2     && < 0.13,
         time        >= 1.9.1     && < 1.13
 

--- a/unix.cabal
+++ b/unix.cabal
@@ -76,7 +76,7 @@ library
     build-depends:
         base        >= 4.12.0.0  && < 4.21,
         bytestring  >= 0.9.2     && < 0.13,
-        time        >= 1.9.1     && < 1.13
+        time        >= 1.9.1     && < 1.15
 
     if flag(os-string)
       build-depends: filepath >= 1.5.0.0, os-string >= 2.0.0


### PR DESCRIPTION
Just as it says on the tin.

Also bump the `base` upper bound in preparation for GHC 9.10.