### PR TITLE
Bump to 2.8.5.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`unix` package](http://hackage.haskell.org/package/unix)
 
+## 2.8.5.1 *Apr 2023*
+
+  * fix building with newer filepath/os-string when `#ifndef HAVE_OPENPTY`
+
 ## 2.8.5.0 *Dec 2023*
 
   * allow building with newer filepath/os-string

--- a/unix.cabal
+++ b/unix.cabal
@@ -1,6 +1,6 @@
 cabal-version:  1.12
 name:           unix
-version:        2.8.5.0
+version:        2.8.5.1
 -- NOTE: Don't forget to update ./changelog.md
 
 license:        BSD3


### PR DESCRIPTION
We need to make a release with bdea7d475e5fb13ea7768a5bbeaaa4600073d829 before GHC 9.10 is finalised.