### PR TITLE
Fix CTimeVal definition for platforms where time_t isn't CLong

### DIFF
--- a/System/Posix/Files/Common.hsc
+++ b/System/Posix/Files/Common.hsc
@@ -551,7 +551,7 @@ foreign import capi unsafe "sys/stat.h futimens"
     c_futimens :: CInt -> Ptr CTimeSpec -> IO CInt
 #endif
 
-data CTimeVal = CTimeVal CLong CLong
+data CTimeVal = CTimeVal (#type time_t) (#type suseconds_t)
 
 instance Storable CTimeVal where
     sizeOf    _ = #size struct timeval


### PR DESCRIPTION
One such platform is Debian unstable armhf, which is in the process of transitioning to 64-bit time_t: https://wiki.debian.org/ReleaseGoals/64bit-time

On that platform (as well as any other glibc/musl platform), however, CTimeVal isn't used for anything at all because there are #ifdefs that prefer using `utimensat` which takes CTimeSpec instead. This fix is therefore quite theoretical, as it is unknown whether there are any platforms actually affected.

Related: https://github.com/haskell/unix/pull/252
