### PR TITLE
Drop old MacOS jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
     - name: Setup toolchain
       run: |
         curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 BOOTSTRAP_HASKELL_GHC_VERSION=${{ matrix.ghc }} BOOTSTRAP_HASKELL_ADJUST_BASHRC=yes sh
+
+    - if: runner.os == 'macOS'
+      name: install system deps via brew
+      run: brew install coreutils autoconf automake
+
     - uses: actions/cache@v4
       name: Cache cabal stuff
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,9 @@ jobs:
       matrix:
         include:
           - os: [self-hosted, FreeBSD, X64]
-            ghc: 9.4.8
+            ghc: 9.4
           - os: [self-hosted, FreeBSD, X64]
-            ghc: 9.6.4
+            ghc: 9.6
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup toolchain
       run: |
-        which ghcup
-        ghcup install cabal recommended
-        ghcup install ghc --set ${{ matrix.ghc }}
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 BOOTSTRAP_HASKELL_GHC_VERSION=${{ matrix.ghc }} BOOTSTRAP_HASKELL_ADJUST_BASHRC=yes sh
+        . ~/.ghcup/env
     - uses: actions/cache@v4
       name: Cache cabal stuff
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
         cd unix-*/
         cabal test all --test-show-details=direct
     - name: Haddock
-      run: cabal haddock --disable-documentation
+      run: |
+        . ~/.ghcup/env
+        cabal haddock --disable-documentation
 
   centos7:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
     - name: Setup toolchain
       run: |
         curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 BOOTSTRAP_HASKELL_GHC_VERSION=${{ matrix.ghc }} BOOTSTRAP_HASKELL_ADJUST_BASHRC=yes sh
-        . ~/.ghcup/env
     - uses: actions/cache@v4
       name: Cache cabal stuff
       with:
@@ -43,6 +42,7 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.ghc }}
     - name: Build
       run: |
+        . ~/.ghcup/env
         ghc --version
         cabal --version
         cabal update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,17 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macOS-latest]
         ghc: ['9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6']
+        exclude:
+          - os: macos-latest
+            ghc: '9.0'
+          - os: macos-latest
+            ghc: '8.10'
+          - os: macos-latest
+            ghc: '8.8'
+          - os: macos-latest
+            ghc: '8.6'
+          - os: macos-latest
+            ghc: '8.4'
     steps:
     - uses: actions/checkout@v4
     - name: Setup toolchain


### PR DESCRIPTION
Drop old MacOS jobs: there are no bindists of old GHCs for `aarch64`, which `macos-latest` now refers to.

We could potentially stick to `macos-13` instead, but whatever, I don't really care that much about old GHCs.