### PR TITLE
Remove `includes` from `.cabal`-file

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -155,9 +155,6 @@ library
     ghc-options: -Wall
 
     include-dirs: include
-    includes:
-        HsUnix.h
-        execvpe.h
     install-includes:
         HsUnix.h
         execvpe.h


### PR DESCRIPTION
This is useless at best, and a common source of confusion.

https://github.com/haskell/cabal/pull/10145
https://github.com/sol/hpack/issues/355