### PR TITLE
Fix support for GHCJS_BROWSER compilation flag of GHC

### DIFF
--- a/jsbits/time.js
+++ b/jsbits/time.js
@@ -1,4 +1,9 @@
+//#OPTIONS: CPP
+
 function h$js_futimes(fd,atime,mtime) {
+#ifdef GHCJS_BROWSER
+    throw "h$js_futimes unsupported";
+#else
   if (!h$isNode()) {
     throw "h$js_futimes unsupported";
   }
@@ -9,9 +14,13 @@ function h$js_futimes(fd,atime,mtime) {
     return -1;
   }
   return 0;
+#endif
 }
 
 function h$js_utimes(path,path_offset,atime,mtime) {
+#ifdef GHCJS_BROWSER
+    throw "h$js_utimes unsupported";
+#else
   if (!h$isNode()) {
     throw "h$js_utimes unsupported";
   }
@@ -23,9 +32,13 @@ function h$js_utimes(path,path_offset,atime,mtime) {
     return -1;
   }
   return 0;
+#endif
 }
 
 function h$js_lutimes(path,path_offset,atime,mtime) {
+#ifdef GHCJS_BROWSER
+    throw "h$js_lutimes unsupported";
+#else
   if (!h$isNode()) {
     throw "h$js_lutimes unsupported";
   }
@@ -37,5 +50,6 @@ function h$js_lutimes(path,path_offset,atime,mtime) {
     return -1;
   }
   return 0;
+#endif
 }
 


### PR DESCRIPTION
See https://gitlab.haskell.org/ghc/ghc/-/issues/25613#note_602248

When compiling `ghc` under GHCJS_BROWSER, all the environment checking code should be removed by the preprocessor. This is not the case for the `jsbits` of the `unix` library, which causes troubles for Google Closure Compiler and bundlers. This PR adds missing directives.