### PR TITLE
Fix `U+2010` typo which prevents successful building on `MSYS2 CLANGARM64` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ tests/*.o
 tests/*.hi
 tests/*.normalised
 *~
+.vscode

--- a/System/Posix/Files/Common.hsc
+++ b/System/Posix/Files/Common.hsc
@@ -993,7 +993,7 @@ defaultStatxMask = mempty
 newtype ExtendedFileStatus = ExtendedFileStatus (ForeignPtr CStatx) -- ^ The constructor is considered internal and may change.
 
 -- | The "preferred" block size for efficient filesystem I/O.
--- (Writing to a file in smaller chunks may cause an inefficient read-mod‐ify-rewrite.)
+-- (Writing to a file in smaller chunks may cause an inefficient read-modify-rewrite.)
 fileBlockSizeX             :: ExtendedFileStatus -> CBlkSize
 #if HAVE_STATX
 -- | Further status information about the file.


### PR DESCRIPTION
GHC JS Backend does not support `TemplateHaskell` and Windows. To investigate this issue I was needed first to build GHC itself to run on Windows 11 ARM (because this hardware is available for me). It was done [here](https://gitlab.haskell.org/ghc/ghc/-/issues/24603#note_602054). And it allowed me to dive in the main [issue](https://gitlab.haskell.org/ghc/ghc/-/issues/25619).

This change allows running a build of GHC JS Backend cross-crompiler by using Windows 11 ARM and a non-cross GHC build for Aarch64.

Without this change [LLVM compilers](https://github.com/mstorsjo/llvm-mingw) at Windows are unable process the build.