### PR TITLE
Use `Base.o_*` instead of raw `{#const O_*}`

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GHC: 9.12.1
       EMSDK: 3.1.74

--- a/.github/workflows/ci-wasm32-wasi.yml
+++ b/.github/workflows/ci-wasm32-wasi.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GHC: 9.10.1.20241021
     steps:

--- a/System/Posix/Semaphore.hsc
+++ b/System/Posix/Semaphore.hsc
@@ -30,6 +30,7 @@ import Foreign.ForeignPtr hiding (newForeignPtr)
 import Foreign.Concurrent
 import Foreign.Ptr
 import System.Posix.Types
+import qualified System.Posix.Internals as Base
 import Control.Concurrent
 import Data.Bits
 #if !defined(HAVE_SEM_GETVALUE)
@@ -61,11 +62,11 @@ newtype Semaphore = Semaphore (ForeignPtr ())
 --   value.
 semOpen :: String -> OpenSemFlags -> FileMode -> Int -> IO Semaphore
 semOpen name flags mode value =
-    let cflags = (if semCreate flags then #{const O_CREAT} else 0) .|.
-                 (if semExclusive flags then #{const O_EXCL} else 0)
+    let cflags = (if semCreate flags then Base.o_CREAT else 0) .|.
+                 (if semExclusive flags then Base.o_EXCL else 0)
         semOpen' cname =
             do sem <- throwErrnoPathIfNull "semOpen" name $
-                      sem_open cname (toEnum cflags) mode (toEnum value)
+                      sem_open cname (toEnum (fromIntegral cflags)) mode (toEnum value)
                fptr <- newForeignPtr sem (finalize sem)
                return $ Semaphore fptr
         finalize sem = throwErrnoPathIfMinus1_ "semOpen" name $

--- a/System/Posix/SharedMem.hsc
+++ b/System/Posix/SharedMem.hsc
@@ -26,6 +26,7 @@ module System.Posix.SharedMem
 #include <fcntl.h>
 
 import System.Posix.Types
+import qualified System.Posix.Internals as Base
 #if defined(HAVE_SHM_OPEN) || defined(HAVE_SHM_UNLINK)
 import Foreign.C
 #endif
@@ -50,14 +51,14 @@ shmOpen :: String -> ShmOpenFlags -> FileMode -> IO Fd
 shmOpen name flags mode =
     do cflags0 <- return 0
        cflags1 <- return $ cflags0 .|. (if shmReadWrite flags
-                                        then #{const O_RDWR}
-                                        else #{const O_RDONLY})
-       cflags2 <- return $ cflags1 .|. (if shmCreate flags then #{const O_CREAT}
+                                        then Base.o_RDWR
+                                        else Base.o_RDONLY)
+       cflags2 <- return $ cflags1 .|. (if shmCreate flags then Base.o_CREAT
                                         else 0)
        cflags3 <- return $ cflags2 .|. (if shmExclusive flags
-                                        then #{const O_EXCL}
+                                        then Base.o_EXCL
                                         else 0)
-       cflags4 <- return $ cflags3 .|. (if shmTrunc flags then #{const O_TRUNC}
+       cflags4 <- return $ cflags3 .|. (if shmTrunc flags then Base.o_TRUNC
                                         else 0)
        withCAString name (shmOpen' cflags4)
     where shmOpen' cflags cname =


### PR DESCRIPTION
`stage1` cross compilers can use different values instead of system-defined. GHC JS Backend overrides these constants to be compatible with Node.js environment.

[Details](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13856#note_620056) of investigation.

Interface stability tests have the following overridden constants:

```
  o_APPEND :: GHC.Internal.Foreign.C.Types.CInt
  o_BINARY :: GHC.Internal.Foreign.C.Types.CInt
  o_CREAT :: GHC.Internal.Foreign.C.Types.CInt
  o_EXCL :: GHC.Internal.Foreign.C.Types.CInt
  o_NOCTTY :: GHC.Internal.Foreign.C.Types.CInt
  o_NONBLOCK :: GHC.Internal.Foreign.C.Types.CInt
  o_RDONLY :: GHC.Internal.Foreign.C.Types.CInt
  o_RDWR :: GHC.Internal.Foreign.C.Types.CInt
  o_TRUNC :: GHC.Internal.Foreign.C.Types.CInt
  o_WRONLY :: GHC.Internal.Foreign.C.Types.CInt
```

Blocks: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13856