### PR TITLE
Bump base upper bound to <4.23

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -77,7 +77,7 @@ library
         buildable: False
 
     build-depends:
-        base        >= 4.12.0.0  && < 4.22,
+        base        >= 4.12.0.0  && < 4.23,
         bytestring  >= 0.9.2     && < 0.13,
         time        >= 1.9.1     && < 1.15
 


### PR DESCRIPTION
Allowing GHC 9.14.