### PR TITLE
Remove readDirStreamWithPtr; replace readdir_r() with readdir()

### DIFF
--- a/System/Posix/Directory/Internals.hsc
+++ b/System/Posix/Directory/Internals.hsc
@@ -46,7 +46,6 @@ module System.Posix.Directory.Internals (
     isWhiteoutType,
     getRealDirType,
     readDirStreamWith,
-    readDirStreamWithPtr,
     ) where
 
 import System.Posix.Directory.Common

--- a/cbits/HsUnix.c
+++ b/cbits/HsUnix.c
@@ -32,73 +32,6 @@ int __hsunix_push_module(int fd, const char *module)
 clock_t __hsunix_clocks_per_second (void) {return CLOCKS_PER_SEC;}
 #endif
 
-/*
- * GNU glibc 2.23 and later deprecate `readdir_r` in favour of plain old
- * `readdir` which in some upcoming POSIX standard is going to required to be
- * re-entrant.
- * Eventually we want to drop `readdir_r` all together, but want to be
- * compatible with older unixen which may not have a re-entrant `readdir`.
- * Solution is to make systems with *known* re-entrant `readdir` use that and use
- * `readdir_r` wherever we have it and don't *know* that `readdir` is
- * re-entrant.
- */
-
-#if defined (__GLIBC__) && ((__GLIBC__ > 2) || (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 23))
-#define USE_READDIR_R 0
-#else
-#define USE_READDIR_R 1
-#endif
-
-/*
- * read an entry from the directory stream; opt for the
- * re-entrant friendly way of doing this, if available.
- */
-int __hscore_readdir( DIR *dirPtr, struct dirent **pDirEnt )
-{
-#if HAVE_READDIR_R && USE_READDIR_R
-  struct dirent* p;
-  int res;
-  static unsigned int nm_max = (unsigned int)-1;
-
-  if (pDirEnt == NULL) {
-    return -1;
-  }
-  if (nm_max == (unsigned int)-1) {
-#ifdef NAME_MAX
-    nm_max = NAME_MAX + 1;
-#else
-    nm_max = pathconf(".", _PC_NAME_MAX);
-    if (nm_max == -1) { nm_max = 255; }
-    nm_max++;
-#endif
-  }
-  p = (struct dirent*)malloc(sizeof(struct dirent) + nm_max);
-  if (p == NULL) return -1;
-  res = readdir_r(dirPtr, p, pDirEnt);
-  if (res != 0) {
-      *pDirEnt = NULL;
-      free(p);
-  }
-  else if (*pDirEnt == NULL) {
-    // end of stream
-    free(p);
-  }
-  return res;
-#else
-
-  if (pDirEnt == NULL) {
-    return -1;
-  }
-
-  *pDirEnt = readdir(dirPtr);
-  if (*pDirEnt == NULL) {
-    return -1;
-  } else {
-    return 0;
-  }
-#endif
-}
-
 char *__hscore_d_name( struct dirent* d )
 {
   return (d->d_name);
@@ -110,12 +43,5 @@ char __hscore_d_type( struct dirent* d )
   return (d->d_type);
 #else
   return CONST_DT_UNKNOWN;
-#endif
-}
-
-void __hscore_free_dirent(struct dirent *dEnt)
-{
-#if HAVE_READDIR_R && USE_READDIR_R
-  free(dEnt);
 #endif
 }


### PR DESCRIPTION
This replaces all use of `readdir_r()` with `readdir()`, and removes `System.Posix.Directory.Internals.readDirStreamWithPtr` as a consequence.  The rationale is 4-fold: _safety,_ _portability,_ _performance,_ and _maintainability._

### Safety

According to the [`readdir_r(3)` manpage](https://www.man7.org/linux/man-pages/man3/readdir_r.3.html), it's unsafe because it's impossible to compute the maximum filename length, hence the size of the buffer to be allocated.  Currently we call `pathconf(".", _PC_NAME_MAX)` when `NAME_MAX` isn't defined.  However, that's the longest filename a process is allowed to create, not the longest than can already be there.  The `fpathconf(3)` manpage explicitly states

> Files with name lengths longer than the value returned for name equal to _PC_NAME_MAX may exist in the given directory.

Even if `NAME_MAX` is defined, the [glibc manual states](https://www.gnu.org/software/libc/manual/html_node/Limits-for-Files.html)

> **Portability Note:** On some systems, the GNU C Library defines `NAME_MAX`, but does not actually enforce this limit.

The `readdir_r(3)` manpage goes on to say that glibc may fail with `ENAMETOOLONG`, but implies there's no way to detect that until the final dirent is read.  On other systems, `d_name` may be truncated, or worse, not null-terminated.

The original reason for `readdir_r()` was to provide a reentrant version of `readdir()`.  However, "in modern implementations" `readdir()` is thread-safe, except for concurrent readers to the same `DIR *` stream.  In that specific case it says the user should do their own synchronization.  This PR adds a warning to that effect.  It's expected (by whom? I don't know) that a future POSIX.1 version will make `readdir()` thread-safe (including to the same `DIR *`, I guess?).

### Portability

`readdir_r()` is deprecated by glibc for the reasons listed above.

### Performance

I compiled [directory-ospath-streaming](https://github.com/sergv/directory-ospath-streaming) against unix before and after these changes and executed [a simple benchmark](https://github.com/sjshuck/directory-ospath-streaming/commit/862f8b578af6605e04be84d785808e8cb52fe7e6) counting files recursively under my home directory (about 500K).  ([Here](https://github.com/sjshuck/directory-ospath-streaming/commit/d6b9902f14caff22b2e354706550360d1a36a6bc) is the change in the streaming library for the after benchmark.)

|        | Haskell                | C             | Time  |
| ------ | ---------------------- | ------------- | ----- |
| Before | `readDirStreamWithPtr` | `readdir_r()` | 550ms |
| After  | `readDirStreamWith`    | `readdir()`   | 545ms |

That 1% improvement was oddly consistent for me, even though tasty-bench claimed &pm;15ms of error.  What's important here is that it isn't worse.  This makes sense.  You're not supposed to free the pointer returned by `readdir()` because it "may be statically allocated".  My guess is a buffer is allocated by `opendir()` or the first call to `readdir()`, and is freed when the kernel cleans up the file descriptor.  If by `opendir()`, then it's a sunk cost&mdash;either way, a user isn't going to do any better by attempting to manage their own `struct dirent` (notwithstanding the safety issues).

For `readdir_r()`, Haskell adds another small cost by allocating the `Ptr (Ptr CDirent)` out param.

### Maintainability

When you glance at `readDirStreamWith` versus `readDirStreamWithPtr` and their types, you might think: "The `Ptr` one is more low-level for when I want to manage memory myself for extra performance/control; the other one probably does that for me each time, trading control for simplicity." Indeed, currently `readDirStreamWith` _does_ do that, and is defined in terms of `readDirStreamWithPtr`.

That intuition is understandable.  But the thing being allocated is simply the extra bookkeeping for reentrancy required by `readdir_r()`.  Currently the note says,

> The lifetime of the pointer wrapped in the `DirEnt` is limited to invocation of the callback and it will be freed automatically after.

This is not true.  The pointer _to that pointer_ is freed, but the `Ptr CDirent` itself is not.  It's moot anyway since this PR reimplements `readDirStreamWith` in terms of `readdir()`.  The note is replaced accordingly.

Also note that the above change to directory-ospath-streaming means the "cache" mechanism there can likely be removed.  It's only there for the `Ptr (Ptr CDirent)` argument.  I'm curious if this leads to more small performance gains.

What I'm getting at in terms of code maintainability is `readdir()` is
* simpler to use
* simpler to make a binding for
* more conducive to simpler user code
* less counter-intuitive

cc @sergv