### PR TITLE
bytestring >=0.11 bound

### DIFF
--- a/unix.cabal
+++ b/unix.cabal
@@ -83,7 +83,7 @@ library
 
     build-depends:
         base        >= 4.12.0.0  && < 4.23,
-        bytestring  >= 0.9.2     && < 0.13,
+        bytestring  >= 0.11      && < 0.13,
         time        >= 1.9.1     && < 1.16
 
     if flag(os-string)


### PR DESCRIPTION
Closes #357.

Prior to `bytestring-0.9.3`, `memcpy` had a different type, breaking `unix-2.7.3` (#357).

Furthermore, since `unix-2.8.0.0` we depend on `filepath >=1.4.100.0`, which already implies `bytestring >=0.11.3`.