### PR TITLE
Fix typos

### DIFF
--- a/System/Posix/Directory.hsc
+++ b/System/Posix/Directory.hsc
@@ -42,7 +42,7 @@ module System.Posix.Directory (
    seekDirStream,
 #endif
 
-   -- * The working dirctory
+   -- * The working directory
    getWorkingDirectory,
    changeWorkingDirectory,
    changeWorkingDirectoryFd,

--- a/System/Posix/Files/Common.hsc
+++ b/System/Posix/Files/Common.hsc
@@ -1002,7 +1002,7 @@ fileAttributesX            :: ExtendedFileStatus -> CAttributes
 #endif
 -- | The number of hard links on a file.
 linkCountX                 :: ExtendedFileStatus -> CNlink
--- | Te user ID of the owner of the file.
+-- | The user ID of the owner of the file.
 fileOwnerX                 :: ExtendedFileStatus -> UserID
 -- | The ID of the group owner of the file.
 fileGroupX                 :: ExtendedFileStatus -> GroupID

--- a/configure.ac
+++ b/configure.ac
@@ -194,7 +194,7 @@ AC_CHECK_FUNCS([lutimes futimes])
 # Additional temp functions
 dnl androids bionic doesn't have mkstemps
 # We explicitly check for android, as the check AC_CHECK_FUNCS performs returns "yes" for mkstemps
-# when targetting android. See similar conditionals for seekdir and telldir.
+# when targeting android. See similar conditionals for seekdir and telldir.
 AS_CASE([$target_os],[*-android*],[AC_CHECK_FUNCS([mkdtemp])],[AC_CHECK_FUNCS([mkstemps mkdtemp])])
 
 # Functions for file synchronization and allocation control


### PR DESCRIPTION
Found via `codespell -S changelog.md -L mis,ake,ovrwrt,nam,clen,bu,ment`